### PR TITLE
Add a base Identifier class used by CommitteeId

### DIFF
--- a/Francken/Base/Identifier.php
+++ b/Francken/Base/Identifier.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Francken\Base;
+
+use Assert\Assertion as Assert;
+
+abstract class Identifier
+{
+    private $id;
+
+    /**
+     * @param string $committeeId
+     */
+    public function __construct($id)
+    {
+        Assert::string($id);
+        Assert::uuid($id);
+
+        $this->id = $id;
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->id;
+    }
+}

--- a/Francken/Committees/CommitteeId.php
+++ b/Francken/Committees/CommitteeId.php
@@ -2,29 +2,8 @@
 
 namespace Francken\Committees;
 
-use Assert\Assertion as Assert;
+use Francken\Base\Identifier;
 
-final class CommitteeId
+final class CommitteeId extends Identifier
 {
-    private $committeeId;
-
-    /**
-     * @param string $committeeId
-     */
-    public function __construct($committeeId)
-    {
-        Assert::string($committeeId);
-        Assert::uuid($committeeId);
-
-        $this->committeeId = $committeeId;
-    }
-
-    /**
-     * @return string
-     */
-    public function __toString()
-    {
-        return $this->committeeId;
-    }
 }
-


### PR DESCRIPTION
Since we will be using more UUID classes that essentially have the same behavior extracting this behavior to a parent class is a good choice.
