### PR TITLE
Add MemberId identifier

### DIFF
--- a/Francken/Members/MemberId.php
+++ b/Francken/Members/MemberId.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Francken\Committees;
+
+use Francken\Base\Identifier;
+
+final class MemberId extends Identifier
+{
+}


### PR DESCRIPTION
Though we probably won't be implementing members for a while, we can
already start using the `MemberId` class when writing tests that integrate
Committees and Activities with members.

I will start writing functionality for members to register for an activity.
This class can also be used when creating functions for adding members to a committee.
