### PR TITLE
Implement generic read model repositories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
     },
     "autoload-dev": {
         "psr-4": {
+            "Francken\\Features\\": "tests/Features",
             "Tests\\": "tests/"
         }
     },

--- a/src/Application/ReadModelNotFound.php
+++ b/src/Application/ReadModelNotFound.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Francken\Application;
+
+final class ReadModelNotFound extends \RunTimeException
+{
+    public static function with(string $id) : ReadModelNotFound
+    {
+        return new ReadModelNotFound(
+            sprintf('Could not find readmodel with id [%s]', $id)
+        );
+    }
+}

--- a/src/Application/ReadModelRepository.php
+++ b/src/Application/ReadModelRepository.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Francken\Application;
+
+use Broadway\ReadModel\ReadModelInterface;
+use Broadway\Serializer\SerializableInterface;
+
+interface ReadModelRepository
+{
+    /**
+     * @param ReadModelInterface $model
+     */
+    public function save(ReadModelInterface $model);
+
+    /**
+     * @param string $id
+     *
+     * @return ReadModelInterface
+     * @throws ReadModelNotFound
+     */
+    public function find(string $id) : ReadModelInterface;
+
+    /**
+     * @param array $fields
+     *
+     * @return ReadModelInterface[]
+     */
+    public function findBy(array $fields) : array;
+
+    /**
+     * @return ReadModelInterface[]
+     */
+    public function findAll() : array;
+
+    /**
+     * @param array $ids
+     * @return ReadModelInterface[]
+     */
+    public function findByIds(array $ids) : array;
+
+    /**
+     * @param string $id
+     */
+    public function remove(string $id);
+
+    /**
+     * @param array $fields
+     */
+    public function removeBy(array $fields);
+}

--- a/src/Infrastructure/Repositories/IlluminateRepository.php
+++ b/src/Infrastructure/Repositories/IlluminateRepository.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Francken\Infrastructure\Repositories;
+
+use Broadway\ReadModel\ReadModelInterface;
+use Broadway\Serializer\SerializableInterface;
+use Francken\Application\ReadModelNotFound;
+use Francken\Application\ReadModelRepository;
+use Illuminate\Database\ConnectionInterface as Connection;
+
+final class IlluminateRepository implements ReadModelRepository
+{
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    /**
+     * @var string
+     */
+    private $table;
+
+    /**
+     * @var string|SerializableInterface|ReadModelInterface
+     */
+    private $model;
+
+    /**
+     * @var string
+     */
+    private $primaryKey;
+
+    /**
+     * @var array
+     */
+    private $stringify;
+
+    /**
+     * IlluminateRepository constructor.
+     * @param Connection $connection
+     * @param string $table
+     * @param string $model
+     * @param string $primaryKey
+     * @param array $stringify Specify the columns which must be stringified
+     */
+    public function __construct(
+        Connection $connection,
+        string $table,
+        string $model,
+        string $primaryKey = 'id',
+        array $stringify = []
+    ) {
+        $this->connection = $connection;
+        $this->table = $table;
+        $this->model = $model;
+        $this->primaryKey = $primaryKey;
+        $this->stringify = $stringify;
+    }
+
+    /**
+     * @param ReadModelInterface $model
+     */
+    public function save(ReadModelInterface $model)
+    {
+        $this->connection->table($this->table)->updateOrInsert([
+            $this->primaryKey => (string)$model->getId()
+        ], $this->serialize($model));
+    }
+
+    /**
+     * @param string $id
+     *
+     * @return ReadModelInterface
+     * @throws ReadModelNotFound
+     */
+    public function find(string $id) : ReadModelInterface
+    {
+        /** @var \stdClass|null $row */
+        $row = $this->connection->table($this->table)->where($this->primaryKey, $id)->first();
+
+        if (is_null($row)) {
+            throw ReadModelNotFound::with($id);
+        }
+
+        return $this->deserialize($row);
+
+    }
+
+    /**
+     * @param array $fields
+     *
+     * @return ReadModelInterface[]
+     */
+    public function findBy(array $fields) : array
+    {
+        if (empty($fields)) {
+            return [];
+        }
+
+        $rows = $this->connection->table($this->table)->where($fields)->get();
+
+        return $this->deserializeRows($rows);
+    }
+
+    /**
+     * @return ReadModelInterface[]
+     */
+    public function findAll() : array
+    {
+        $rows = $this->connection->table($this->table)->get();
+
+        return $this->deserializeRows($rows);
+    }
+
+    /**
+     * @param array $ids
+     * @return ReadModelInterface[]
+     */
+    public function findByIds(array $ids) : array
+    {
+        $rows = $this->connection->table($this->table)->whereIn($this->primaryKey, $ids)->get();
+
+        return $this->deserializeRows($rows);
+    }
+
+    /**
+     * @param string $id
+     */
+    public function remove(string $id)
+    {
+        $this->connection->table($this->table)->where($this->primaryKey, $id)->delete();
+    }
+
+    /**
+     * @param array $fields
+     */
+    public function removeBy(array $fields)
+    {
+        if (empty($fields)) {
+            return;
+        }
+
+        $this->connection->table($this->table)->where($fields)->delete();
+    }
+
+    // We migth want to replace these methods with a generic serializer
+
+    /**
+     * Since SQL databases are normalized, nested arrays
+     * must be serialized to JSON.
+     * @param SerializableInterface $model
+     * @return array
+     */
+    private function serialize(SerializableInterface $model) : array
+    {
+        return $model->serialize();
+    }
+
+    /**
+     * Since SQL databases are normalized, nested structures
+     * muse be deserialized from JSON to arrays.
+     * @param \stdClass $object
+     * @return ReadModelInterface
+     */
+    private function deserialize(\stdClass $object) : ReadModelInterface
+    {
+        return ($this->model)::deserialize((array)$object);
+    }
+
+
+    /**
+     * @param array $rows
+     * @return array
+     */
+    private function deserializeRows(array $rows) : array
+    {
+        return array_map(
+            function ($row) {
+                return $this->deserialize($row);
+            },
+            $rows
+        );
+    }
+}

--- a/src/Infrastructure/Repositories/InMemoryRepository.php
+++ b/src/Infrastructure/Repositories/InMemoryRepository.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Francken\Infrastructure\Repositories;
+
+use Broadway\ReadModel\ReadModelInterface;
+use Francken\Application\ReadModelNotFound;
+use Francken\Application\ReadModelRepository;
+use ReflectionClass;
+use stdClass;
+
+final class InMemoryRepository implements ReadModelRepository
+{
+    private $data = [];
+
+    /**
+     * @var null
+     */
+    private $model;
+
+    /** @var \ReflectionProperty[] */
+    private $properties = [];
+
+    public function __construct($model = stdClass::class)
+    {
+        $this->model = $model;
+
+        foreach ((new ReflectionClass($model))->getProperties() as $property) {
+            $this->properties[$property->getName()] = $property;
+            $property->setAccessible(true);
+        }
+    }
+
+    /**
+     * @param ReadModelInterface $model
+     */
+    public function save(ReadModelInterface $model)
+    {
+        $this->data[(string)$model->getId()] = $model;
+    }
+
+    /**
+     * @param string $id
+     *
+     * @return ReadModelInterface
+     * @throws ReadModelNotFound
+     */
+    public function find(string $id) : ReadModelInterface
+    {
+        if (isset($this->data[$id])) {
+            return $this->data[$id];
+        }
+
+        throw ReadModelNotFound::with($id);
+    }
+
+    /**
+     * @param array $fields
+     *
+     * @return ReadModelInterface[]
+     */
+    public function findBy(array $fields) : array
+    {
+        if (! $this->fieldsAreValid($fields)) {
+            return [];
+        }
+
+        return array_values(
+            array_filter(
+                $this->data,
+                function ($model) use ($fields) {
+                    foreach ($fields as $field => $value) {
+                        if ($this->properties[$field]->getValue($model) != $value) {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                }
+            )
+        );
+    }
+
+    /**
+     * @return ReadModelInterface[]
+     */
+    public function findAll() : array
+    {
+        return array_values($this->data);
+    }
+
+    /**
+     * @param array $ids
+     * @return ReadModelInterface[]
+     */
+    public function findByIds(array $ids) : array
+    {
+        return array_values(array_intersect_key($this->data, array_flip($ids)));
+    }
+
+    /**
+     * @param string $id
+     */
+    public function remove(string $id)
+    {
+        unset($this->data[(string)$id]);
+    }
+
+    /**
+     * @param array $fields
+     */
+    public function removeBy(array $fields)
+    {
+        $remove = [];
+        foreach ($this->findBy($fields) as $model) {
+            $remove[$model->getId()] = $model;
+        }
+
+        $this->data = array_diff_key($this->data, $remove);
+    }
+
+    /**
+     * Check that the fields (used for searching) are valid
+     * If the fields are empty, or if they contain at least one key that
+     * is not present as a property of our model then the field is not valid
+     */
+    private function fieldsAreValid(array $fields) : bool
+    {
+        if (empty($fields)) {
+            return false;
+        }
+
+        // Check that all fields are included in the properties of our model
+        if (array_keys(array_intersect_key($fields, $this->properties)) !== array_keys($fields)) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/tests/Features/Repositories/IlluminateRepositoryFeature.php
+++ b/tests/Features/Repositories/IlluminateRepositoryFeature.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Francken\Features\Repositories;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+use Francken\Application\ReadModelRepository;
+use Francken\Infrastructure\Repositories\IlluminateRepository;
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Database\ConnectionInterface as Connection;
+use Illuminate\Foundation\Application;
+
+class IlluminateRepositoryFeature extends RepositoryTestCase
+{
+    /** @var Application|null $app */
+    private $app;
+
+    /** @var Kernel */
+    private $kernel;
+
+    /**
+     * Setup the App
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        putenv('APP_ENV=testing');
+        $this->app = require __DIR__ . '/../../../bootstrap/app.php';
+
+        /** @var Kernel $kernel */
+        $this->kernel = $this->app->make(Kernel::class);
+        $this->kernel->bootstrap();
+        $this->kernel->call('migrate');
+
+        Schema::create('testing_table', function (Blueprint $table) {
+            $table->string('id');
+            $table->string('first');
+            $table->string('second');
+        });
+    }
+
+    protected function tearDown()
+    {
+        Schema::drop('testing_table');
+        $this->kernel->call('migrate:rollback');
+        $this->app->flush();
+        $this->app = null;
+        parent::tearDown();
+    }
+
+    protected function createRepository() : ReadModelRepository
+    {
+        $connection = $this->app->make(Connection::class);
+        return new IlluminateRepository(
+            $connection,
+            'testing_table',
+            TestReadModel::class,
+            'id'
+        );
+    }
+}

--- a/tests/Features/Repositories/InMemoryRepositoryFeature.php
+++ b/tests/Features/Repositories/InMemoryRepositoryFeature.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Francken\Features\Repositories;
+
+use Francken\Application\ReadModelRepository;
+use Francken\Infrastructure\Repositories\InMemoryRepository;
+
+class InMemoryRepositoryFeature extends RepositoryTestCase
+{
+    protected function createRepository() : ReadModelRepository
+    {
+        return new InMemoryRepository(TestReadModel::class);
+    }
+}

--- a/tests/Features/Repositories/RepositoryTestCase.php
+++ b/tests/Features/Repositories/RepositoryTestCase.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Francken\Features\Repositories;
+
+use BroadwaySerialization\Hydration\HydrateUsingReflection;
+use BroadwaySerialization\Reconstitution\ReconstituteUsingInstantiatorAndHydrator;
+use BroadwaySerialization\Reconstitution\Reconstitution;
+use Doctrine\Instantiator\Instantiator;
+use Francken\Application\ReadModelNotFound;
+use Francken\Application\ReadModelRepository;
+use PHPUnit_Framework_TestCase as TestCase;
+
+abstract class RepositoryTestCase extends TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        // Not 100% sure if this belongs here or in the implementations
+        Reconstitution::reconstituteUsing(
+            new ReconstituteUsingInstantiatorAndHydrator(
+                new Instantiator(),
+                new HydrateUsingReflection()
+            )
+        );
+    }
+
+    /** @test */
+    public function it_saves_and_finds_a_model()
+    {
+        $repo = $this->createRepository();
+
+        $model = $this->createReadModel('1', 'Some data', 'More data');
+
+        $repo->save($model);
+
+        $this->assertEquals($model, $repo->find('1'));
+    }
+
+    /** @test */
+    function it_cant_find_nonexisting_models()
+    {
+        $this->expectException(ReadModelNotFound::class);
+
+        $repo = $this->createRepository();
+        $repo->find('42');
+    }
+
+    /**
+     * @group hoi
+     * @test
+     */
+    public function it_finds_by_fields()
+    {
+        $repo = $this->createRepository();
+
+        $model1 = $this->createReadModel('42', 'This', 'Hi');
+        $model2 = $this->createReadModel('43', 'This', 'Hello');
+        $model3 = $this->createReadModel('44', 'What', 'Hello');
+
+        $repo->save($model1);
+        $repo->save($model2);
+        $repo->save($model3);
+
+        $this->assertEquals([$model2], $repo->findBy([
+            'first' => 'This',
+            'second' => 'Hello'
+        ]));
+    }
+
+    /** @test */
+    function looking_for_fields_that_dont_exist_will_have_no_result()
+    {
+        $repo = $this->createRepository();
+
+        $model1 = $this->createReadModel('42', 'This', 'Hi');
+        $model2 = $this->createReadModel('43', 'This', 'Hello');
+        $model3 = $this->createReadModel('44', 'What', 'Hello');
+
+        $repo->save($model1);
+        $repo->save($model2);
+        $repo->save($model3);
+
+        $this->assertEquals([], $repo->findBy([
+            'first' => 'This',
+            'second' => 'Hello',
+            'does-not-exist' => ''
+        ]));
+    }
+
+
+    /** @test */
+    public function it_returns_nothing_when_no_fields_are_set()
+    {
+        $repo = $this->createRepository();
+
+        $model1 = $this->createReadModel('42', 'This', 'Hi');
+
+        $repo->save($model1);
+
+        $this->assertEmpty($repo->findBy([]));
+    }
+
+    /** @test */
+    public function it_finds_all()
+    {
+        $repo = $this->createRepository();
+
+        $model1 = $this->createReadModel('42', 'Some data', 'More');
+        $model2 = $this->createReadModel('43', 'More data', 'Well hi');
+
+        $repo->save($model1);
+        $repo->save($model2);
+
+        $this->assertEquals(
+            [$model1, $model2],
+            $repo->findAll(),
+            '', 0.0, 10, true // canonical order
+        );
+    }
+
+    /** @test */
+    public function it_finds_existing_ids()
+    {
+        $repo = $this->createRepository();
+
+        $model1 = $this->createReadModel('42', 'Some data', 'Hi');
+        $model2 = $this->createReadModel('43', 'More data', 'There');
+        $model3 = $this->createReadModel('44', 'Last bit', 'Hello');
+
+        $repo->save($model1);
+        $repo->save($model2);
+        $repo->save($model3);
+
+        // None of the two exit
+        $this->assertEmpty($repo->findByIds(['16', '12']));
+
+        // Only one exists
+        $this->assertEquals(
+            [$model1],
+            $repo->findByIds(['16', '42'])
+        );
+
+        // Both exist
+        $this->assertEquals(
+            [$model1, $model3],
+            $repo->findByIds(['42', '44']),
+            '', 0.0, 10, true // canonical order
+        );
+    }
+
+    /** @test */
+    public function it_removes_models()
+    {
+        $repo = $this->createRepository();
+
+        $model = $this->createReadModel('42', 'First', 'Second');
+
+        $repo->save($model);
+        $repo->remove('42');
+
+        $this->expectException(ReadModelNotFound::class);
+        $repo->find('42');
+    }
+
+    /** @test */
+    public function removing_unknown_models_is_done_without_throwing()
+    {
+        $repo = $this->createRepository();
+        $repo->remove('nonexisting');
+    }
+
+    /** @test */
+    public function it_removes_by_fields_only_if_they_are_provided()
+    {
+        $repo = $this->createRepository();
+
+        $model1 = $this->createReadModel('42', 'This', 'Hi');
+        $model2 = $this->createReadModel('43', 'This', 'Hello');
+        $model3 = $this->createReadModel('44', 'What', 'Hello');
+
+        $repo->save($model1);
+        $repo->save($model2);
+        $repo->save($model3);
+
+        // Remove nothing if nothing is provided
+        $repo->removeBy([]);
+        $this->assertEquals(
+            [$model1, $model2, $model3],
+            $repo->findAll(),
+            '', 0.0, 10, true // canonical order
+        );
+
+        // Removes the second model only
+        $repo->removeBy([
+            'first' => 'This',
+            'second' => 'Hello',
+        ]);
+
+        $this->assertEquals(
+            [$model1, $model3],
+            $repo->findAll(),
+            '', 0.0, 10, true // canonical order
+        );
+    }
+
+    /**
+     * Return an instance of a read model
+     * @param string $id
+     * @param string $first
+     * @param string $second
+     * @return TestReadModel
+     */
+    protected function createReadModel(string $id, string $first, string $second) : TestReadModel
+    {
+        return TestReadModel::create($id, $first, $second);
+    }
+
+    /**
+     * Provide an instance of the repository that must be tested
+     * @return ReadModelRepository
+     */
+    abstract protected function createRepository() : ReadModelRepository;
+}

--- a/tests/Features/Repositories/TestReadModel.php
+++ b/tests/Features/Repositories/TestReadModel.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Francken\Features\Repositories;
+
+use Broadway\ReadModel\ReadModelInterface;
+use Broadway\Serializer\SerializableInterface;
+use BroadwaySerialization\Serialization\Serializable;
+
+final class TestReadModel implements ReadModelInterface, SerializableInterface
+{
+    use Serializable;
+
+    private $id;
+    private $first;
+    private $second;
+
+    public static function create(string $id, string $first, string $second) : TestReadModel
+    {
+        $instance = new self;
+        $instance->id = $id;
+        $instance->first = $first;
+        $instance->second = $second;
+        return $instance;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+}


### PR DESCRIPTION
By having generic repositories we can have serializable read models that we can both store in memory (making it easy to test them in combination with projectors) or in a SQL table using the `IlluminateRepository`.