### PR TITLE
Add infrastructure and application code for managing the Francken Vrij

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,10 @@ env:
     - APP_KEY=SomeRandomStringSomeRandomString
 
 before_script:
-  - pecl install imagick
+  - sudo add-apt-repository -y ppa:moti-p/cc
+  - sudo apt-get update
+  - sudo apt-get -y --reinstall install imagemagick
+  - printf "\n" | pecl install imagick-beta
   - composer selfupdate
   - composer install --prefer-dist
 

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -48,6 +48,13 @@ return [
             'root'   => storage_path('app'),
         ],
 
+
+        'public' => [
+            'driver' => 'local',
+            'root' => public_path('storage'),
+            'visibility' => 'public',
+        ],
+
         'ftp' => [
             'driver'   => 'ftp',
             'host'     => 'ftp.example.com',

--- a/database/migrations/2016_11_23_143537_create_francken_vrij_table.php
+++ b/database/migrations/2016_11_23_143537_create_francken_vrij_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateFranckenVrijTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('francken_vrij', function (Blueprint $table) {
+            $table->uuid('id');
+            $table->string('title');
+            $table->integer('volume');
+            $table->integer('edition');
+            $table->string('pdf');
+            $table->string('cover');
+
+            $table->unique(['volume', 'edition']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('francken_vrij');
+    }
+}

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -24,5 +24,6 @@ class DatabaseSeeder extends Seeder
         $this->call(PostsSeeder::class);
         $this->call(RegistrationRequestsSeeder::class);
         $this->call(BooksSeeder::class);
+        $this->call(FranckenVrijSeeder::class);
     }
 }

--- a/database/seeds/FranckenVrijSeeder.php
+++ b/database/seeds/FranckenVrijSeeder.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Francken\Application\FranckenVrij\Edition;
+use Francken\Application\FranckenVrij\FranckenVrijRepository;
+use Francken\Domain\FranckenVrij\EditionId;
+use Illuminate\Database\Seeder;
+use Francken\Domain\Url;
+
+final class FranckenVrijSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $editions = App::make(FranckenVrijRepository::class);
+
+        // Save all existing editions
+        foreach (range(20, 1, -1) as $volume) {
+            foreach (range(1, 3) as $edition) {
+                $editions->save(
+                    Edition::publish(
+                        EditionId::generate(),
+                        "Francken Vrij " . $volume . '.' . $edition,
+                        $volume,
+                        $edition,
+                        new Url("http://www.professorfrancken.nl/franckenvrij/webplaatjes/{$volume}.{$edition}.jpg"),
+                        new Url("http://www.professorfrancken.nl/franckenvrij/{$volume}.{$edition}.pdf")
+                    )
+                );
+            }
+        }
+    }
+}

--- a/src/Application/FranckenVrij/Edition.php
+++ b/src/Application/FranckenVrij/Edition.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Francken\Application\FranckenVrij;
+
+use BroadwaySerialization\Serialization\Serializable;
+use Broadway\ReadModel\ReadModelInterface;
+use Broadway\Serializer\SerializableInterface;
+use Francken\Domain\FranckenVrij\EditionId;
+use Francken\Domain\Url;
+use InvalidArgumentException;
+
+final class Edition implements ReadModelInterface, SerializableInterface
+{
+    use Serializable;
+
+    private $title;
+    private $volume;
+    private $edition;
+
+    private $cover;
+    private $pdf;
+    private $id;
+
+    private function __construct()
+    {
+
+    }
+
+    public static function publish(
+        EditionId $id,
+        string $title,
+        int $volume,
+        int $edition,
+        Url $cover,
+        Url $pdf
+    ) : Edition {
+        $vrij = new Edition;
+
+        if ($volume <= 0) {
+            throw new InvalidargumentException("Volume must be positive, [{$volume}] given");
+        }
+
+        if (($edition <= 0) || ($edition > 3)) {
+            throw new InvalidargumentException("Edition number must be between 1 and 3, [{$edition}]");
+        }
+
+        $vrij->title = $title;
+        $vrij->volume = $volume;
+        $vrij->edition = $edition;
+        $vrij->cover = (string)$cover;
+        $vrij->pdf = (string)$pdf;
+        $vrij->id = (string)$id;
+
+        return $vrij;
+    }
+
+    public function getId() : string
+    {
+        return $this->id;
+    }
+
+    public function title() : string
+    {
+        return $this->title;
+    }
+
+    public function volume() : int
+    {
+        return (int)$this->volume;
+    }
+
+    public function edition() : int
+    {
+        return (int)$this->edition;
+    }
+
+    public function pdf() : Url
+    {
+        return new Url($this->pdf);
+    }
+
+    public function cover() : Url
+    {
+        return new Url($this->cover);
+    }
+}

--- a/src/Application/FranckenVrij/FranckenVrijRepository.php
+++ b/src/Application/FranckenVrij/FranckenVrijRepository.php
@@ -21,6 +21,11 @@ final class FranckenVrijRepository
         $this->repo->save($edition);
     }
 
+    public function remove(EditionId $id)
+    {
+        $this->repo->remove((string)$id);
+    }
+
     public function find(EditionId $id)
     {
         return $this->repo->find((string)$id);

--- a/src/Application/FranckenVrij/FranckenVrijRepository.php
+++ b/src/Application/FranckenVrij/FranckenVrijRepository.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Francken\Application\FranckenVrij;
+
+use Francken\Application\ReadModelRepository;
+
+final class FranckenVrijRepository
+{
+    private $repo;
+
+    public function __construct(ReadModelRepository $repo)
+    {
+        $this->repo = $repo;
+    }
+
+    public function save(Edition $edition)
+    {
+        $this->repo->save($edition);
+    }
+
+    public function findAll() : array
+    {
+        return $this->repo->findAll();
+    }
+
+    public function volumes() : array
+    {
+        $volumes = [];
+
+        // Group each edition into a volume
+        foreach ($this->findAll() as $vrij) {
+            $volumes[$vrij->volume()] ?? ['volume' => $vrij->volume(), 'editions' => []];
+            $volumes[$vrij->volume()]['editions'][] = $vrij;
+            $volumes[$vrij->volume()]['volume'] = $vrij->volume();
+        }
+
+        // Map the volumes to a Volume object
+        $v = array_map(function ($volume) {
+            return new Volume($volume['volume'], $volume['editions']);
+        }, $volumes);
+
+        usort($v, function (Volume $a, Volume $b) {
+            return $b->volume() <=> $a->volume();
+        });
+
+        return $v;
+    }
+}

--- a/src/Application/FranckenVrij/FranckenVrijRepository.php
+++ b/src/Application/FranckenVrij/FranckenVrijRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Francken\Application\FranckenVrij;
 
 use Francken\Application\ReadModelRepository;
+use Francken\Domain\FranckenVrij\EditionId;
 
 final class FranckenVrijRepository
 {
@@ -18,6 +19,11 @@ final class FranckenVrijRepository
     public function save(Edition $edition)
     {
         $this->repo->save($edition);
+    }
+
+    public function find(EditionId $id)
+    {
+        return $this->repo->find((string)$id);
     }
 
     public function findAll() : array

--- a/src/Application/FranckenVrij/Volume.php
+++ b/src/Application/FranckenVrij/Volume.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Francken\Application\FranckenVrij;
+
+use InvalidArgumentException;
+
+final class Volume
+{
+    private $volume;
+    private $editions;
+
+    public function __construct(int $volume, array $editions)
+    {
+        $this->volume = $volume;
+        $this->setEditions(...$editions);
+    }
+
+    public function volume() : int
+    {
+        return $this->volume;
+    }
+
+    public function editions() : array
+    {
+        return $this->editions;
+    }
+
+    private function setEditions(Edition ...$editions)
+    {
+        foreach ($editions as $edition) {
+            if ($edition->volume() !== $this->volume) {
+                throw new InvalidArgumentException(
+                    sprintf(
+                        "Tried to add edition of volume [%d] to volume [%d]",
+                        $edition->volume(),
+                        $this->volume
+                    )
+                );
+            }
+        }
+
+        $this->editions = $editions;
+    }
+}

--- a/src/Domain/FranckenVrij/EditionId.php
+++ b/src/Domain/FranckenVrij/EditionId.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Francken\Domain\FranckenVrij;
+
+use Francken\Domain\Identifier;
+
+final class EditionId extends Identifier
+{
+}

--- a/src/Domain/Url.php
+++ b/src/Domain/Url.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Francken\Domain;
+
+final class Url
+{
+    private $url;
+
+    public function __construct(string $url)
+    {
+        if (! filter_var($url, FILTER_VALIDATE_URL)) {
+            throw new \InvalidArgumentException;
+        }
+
+        $this->url = $url;
+    }
+
+    public function __toString() : string
+    {
+        return $this->url;
+    }
+}

--- a/src/Domain/Url.php
+++ b/src/Domain/Url.php
@@ -11,7 +11,9 @@ final class Url
     public function __construct(string $url)
     {
         if (! filter_var($url, FILTER_VALIDATE_URL)) {
-            throw new \InvalidArgumentException;
+            throw new \InvalidArgumentException(
+                sprintf("[%s] is not a valid URL", $url)
+            );
         }
 
         $this->url = $url;

--- a/src/Infrastructure/AppServiceProvider.php
+++ b/src/Infrastructure/AppServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Francken\Infrastructure;
 
-use Francken\Application\ReadModelRepository;
 use Broadway\EventSourcing\EventSourcingRepository;
 use Francken\Application\Books\AvailableBook;
 use Francken\Application\Books\AvailableBooksRepository;
@@ -10,8 +9,11 @@ use Francken\Application\Books\BookDetailsRepositoryI;
 use Francken\Application\Committees\CommitteesList;
 use Francken\Application\Committees\CommitteesListProjector;
 use Francken\Application\Committees\CommitteesListRepository;
+use Francken\Application\FranckenVrij\FranckenVrijRepository;
+use Francken\Application\FranckenVrij\Edition;
 use Francken\Application\Members\Registration\RequestStatus;
 use Francken\Application\Members\Registration\RequestStatusRepository;
+use Francken\Application\ReadModelRepository;
 use Francken\Application\ReadModel\MemberList\MemberList;
 use Francken\Application\ReadModel\MemberList\MemberListRepository;
 use Francken\Application\ReadModel\PostList\PostList;
@@ -70,6 +72,10 @@ final class AppServiceProvider extends ServiceProvider
         [
             AvailableBooksRepository::class,
             ['available_books', AvailableBook::class, 'id']
+        ],
+        [
+            FranckenVrijRepository::class,
+            ['francken_vrij', Edition::class, 'id']
         ],
     ];
 
@@ -135,6 +141,8 @@ final class AppServiceProvider extends ServiceProvider
 
         // Responsible for getting the book cover from Amazon
         $this->app->bind(BookDetailsRepositoryI::class, BookDetailsRepository::class);
+
+        $this->app->bind(ReadModelRepository::class, \Francken\Infrastructure\Repositories\InMemoryRepository::class);
 
         // In this case we don't want Laravel to resolve the CommonMarkConverter since
         // this would mean that Laravel would provide the converter with an environment,

--- a/src/Infrastructure/Http/Controllers/Admin/FranckenVrijController.php
+++ b/src/Infrastructure/Http/Controllers/Admin/FranckenVrijController.php
@@ -139,6 +139,13 @@ final class FranckenVrijController extends Controller
         return redirect('/admin/francken-vrij');
     }
 
+    public function destroy(string $id)
+    {
+        $this->franckenVrij->remove(new EditionId($id));
+
+        return redirect('/admin/francken-vrij');
+    }
+
     private function uploadPdf(UploadedFile $pdf, $filename)
     {
         $pdfPath = $pdf->storeAs('francken-vrij', $filename, 'public');

--- a/src/Infrastructure/Http/Controllers/Admin/FranckenVrijController.php
+++ b/src/Infrastructure/Http/Controllers/Admin/FranckenVrijController.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Francken\Infrastructure\Http\Controllers\Admin;
+
+use Francken\Application\FranckenVrij\Edition;
+use Francken\Application\FranckenVrij\FranckenVrijRepository;
+use Francken\Application\FranckenVrij\Volume;
+use Francken\Domain\FranckenVrij\EditionId;
+use Francken\Domain\Url;
+use Francken\Infrastructure\Http\Controllers\Controller;
+use Illuminate\Contracts\Filesystem\Factory;
+use Illuminate\Foundation\Validation\ValidatesRequests;
+use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
+
+final class FranckenVrijController extends Controller
+{
+    use ValidatesRequests;
+
+    private $franckenVrij;
+    private $storage;
+
+    public function __construct(FranckenVrijRepository $franckenVrij, Factory $storage)
+    {
+        $this->franckenVrij = $franckenVrij;
+        $this->storage = $storage;
+    }
+
+    public function index()
+    {
+        $volumes = $this->franckenVrij->volumes();
+
+        // Predict the next volume and edition numbers
+        $currentVolume = array_reduce(
+            $volumes,
+            function (Volume $max, Volume $volume) {
+                return $volume->volume() > $max->volume() ? $volume : $max;
+            },
+            new Volume(1, [])
+        );
+
+        $currentEdition = array_reduce(
+            $currentVolume->editions(),
+            function (int $max, Edition $edition) {
+                return $edition->edition() > $max ? $edition->edition() : $max;
+            },
+            0
+        );
+
+        $currentVolume = $currentVolume->volume();
+        if ($currentEdition === 3) {
+            $currentVolume++;
+            $currentEdition = 0;
+        }
+        $currentEdition++;
+
+        $title = 'Francken Vrij ' . $currentVolume . '.' . $currentEdition;
+
+        return view('admin.francken-vrij.index', [
+            'volumes' => $volumes,
+            'title' => $title,
+            'volume' => $currentVolume,
+            'edition' => $currentEdition,
+            'useFrontPageAsCover' => true,
+        ]);
+    }
+
+    /**
+     * Store a new Francken Vrij edition
+     */
+    public function store(Request $request)
+    {
+        $title = $request->get('title');
+        $volume = (int)$request->get('volume');
+        $edition = (int)$request->get('edition');
+
+        $this->validate($request, [
+            'title' => 'required',
+            'volume' => 'required|min:1',
+            'edition' => 'required|min:1|max:3',
+            'pdf' => 'required|file'
+        ]);
+
+        $edition = $this->createEdition(
+            $title,
+            $volume,
+            $edition,
+            $request->file('pdf')
+        );
+
+        $this->franckenVrij->save($edition);
+
+        return redirect('/admin/francken-vrij');
+    }
+
+    private function createEdition(
+        string $title,
+        int $volume,
+        int $edition,
+        UploadedFile $pdf
+    ) : Edition {
+        $pdfPath = $pdf->storeAs('francken-vrij', $volume . '-' . $edition . '.pdf', 'public');
+        $coverPath = preg_replace('"\.pdf$"', '-cover.png', $pdfPath);
+
+        $this->generateCoverImageFromPdf(
+            public_path() . $this->storage->url($pdfPath),
+            $coverPath
+        );
+
+        return Edition::publish(
+            EditionId::generate(),
+            $title,
+            $volume,
+            $edition,
+            new Url(asset($this->storage->url($coverPath))),
+            new Url(asset($this->storage->url($pdfPath)))
+        );
+    }
+
+    private function generateCoverImageFromPdf(string $pdfPath, string $coverPath) : string
+    {
+        $imagick = new \Imagick();
+        $imagick->setCompressionQuality(100);
+        $imagick->setResolution(300, 300);
+        $imagick->readImage($pdfPath . '[0]');
+        $imagick->resizeImage(175, 245, \Imagick::FILTER_LANCZOS, 0.9);
+        $imagick->transformImageColorspace(\Imagick::COLORSPACE_SRGB);
+        $imagick->setFormat('png');
+
+        $this->storage->disk('public')->put($coverPath, $imagick);
+
+        return $coverPath;
+    }
+}

--- a/src/Infrastructure/Http/Views/admin/francken-vrij/_create.blade.php
+++ b/src/Infrastructure/Http/Views/admin/francken-vrij/_create.blade.php
@@ -1,0 +1,38 @@
+<h4>Publish a Francken Vrij</h4>
+
+{!! Form::open(['url' => 'admin/francken-vrij', 'files' => true]) !!}
+
+<div class="form-group">
+    {!! Form::label('title', 'Title:', ['class' => 'control-label']) !!}
+    {!! Form::text('title', $title, ['class' => 'form-control']) !!}
+</div>
+
+<div class="row">
+    <div class="col-sm-6">
+        <div class="form-group">
+            {!! Form::label('volume', 'Volume:', ['class' => 'control-label']) !!}
+            {!! Form::number('volume', $volume, ['class' => 'form-control', 'min' => 1]) !!}
+        </div>
+    </div>
+
+    <div class="col-sm-6">
+        <div class="form-group">
+            {!! Form::label('edition', 'Edition:', ['class' => 'control-label']) !!}
+            {!! Form::number('edition', $edition, ['class' => 'form-control', 'min' => 1, 'max' => 3]) !!}
+        </div>
+    </div>
+</div>
+
+<div class="form-group">
+    <p>
+        Upload the pdf of the new Francken Vrij. Note we currently only support uploading files which are less than 40MB.
+    </p>
+    {!! Form::label('pdf', 'Francken Vrij PDF', ['class' => 'control-label']) !!}
+    {!! Form::file('pdf') !!}
+</div>
+
+{!! Form::submit('Publish', ['class' => 'btn btn-primary']) !!}
+
+{!! Form::close() !!}
+
+@include('admin._errors')

--- a/src/Infrastructure/Http/Views/admin/francken-vrij/edit.blade.php
+++ b/src/Infrastructure/Http/Views/admin/francken-vrij/edit.blade.php
@@ -39,4 +39,11 @@
     {!! Form::close() !!}
 
     @include('admin._errors')
+
+    {!! Form::open(['url' => '/admin/francken-vrij/' . $edition->getId(), 'method' => 'delete']) !!}
+    <button class="btn btn-danger">
+        <i class="fa fa-trash-o" aria-hidden="true"></i>
+        Archive
+    </button>
+    {!! Form::close() !!}
 @endsection

--- a/src/Infrastructure/Http/Views/admin/francken-vrij/edit.blade.php
+++ b/src/Infrastructure/Http/Views/admin/francken-vrij/edit.blade.php
@@ -1,0 +1,42 @@
+@extends('admin.layout')
+
+@section('content')
+    <h1 class="page-header">Edit {{ $edition->title() }}</h1>
+
+    {!! Form::open(['url' => "/admin/francken-vrij/" . $edition->getId(), 'files' => true, 'method' => 'put']) !!}
+
+    <div class="form-group">
+        {!! Form::label('title', 'Title:', ['class' => 'control-label']) !!}
+        {!! Form::text('title', $edition->title(), ['class' => 'form-control']) !!}
+    </div>
+
+    <div class="row">
+        <div class="col-sm-6">
+            <div class="form-group">
+                {!! Form::label('volume', 'Volume:', ['class' => 'control-label']) !!}
+                {!! Form::number('volume', $edition->volume(), ['class' => 'form-control', 'min' => 1]) !!}
+            </div>
+        </div>
+
+        <div class="col-sm-6">
+            <div class="form-group">
+                {!! Form::label('edition', 'Edition:', ['class' => 'control-label']) !!}
+                {!! Form::number('edition', $edition->edition(), ['class' => 'form-control', 'min' => 1, 'max' => 3]) !!}
+            </div>
+        </div>
+    </div>
+
+    <div class="form-group">
+        <p>
+            You may optionally reupload the Francken Vrij Pdf
+        </p>
+        {!! Form::label('pdf', 'Francken Vrij PDF', ['class' => 'control-label']) !!}
+        {!! Form::file('pdf') !!}
+    </div>
+
+    {!! Form::submit('Update', ['class' => 'btn btn-primary']) !!}
+
+    {!! Form::close() !!}
+
+    @include('admin._errors')
+@endsection

--- a/src/Infrastructure/Http/Views/admin/francken-vrij/index.blade.php
+++ b/src/Infrastructure/Http/Views/admin/francken-vrij/index.blade.php
@@ -1,0 +1,30 @@
+@extends('admin.layout')
+
+@section('content')
+    <h1 class="page-header">Francken Vrij</h1>
+
+    <div class="row">
+        <div class="col-sm-4">
+            @include('admin.francken-vrij._create')
+        </div>
+
+        <div class="col-sm-8">
+            <h4>Our collection</h4>
+            @foreach ($volumes as $volume)
+                <div class="row">
+                    @foreach ($volume->editions() as $edition)
+                        <div class="col-sm-4">
+                            <h5>
+                                {{ $edition->title() }}
+
+                                <span class="text-right pull-right">
+                                    <small>Edit | Download</small>
+                                </span>
+                            </h5>
+                        </div>
+                    @endforeach
+                </div>
+            @endforeach
+        </div>
+    </div>
+@endsection

--- a/src/Infrastructure/Http/Views/admin/francken-vrij/index.blade.php
+++ b/src/Infrastructure/Http/Views/admin/francken-vrij/index.blade.php
@@ -18,7 +18,10 @@
                                 {{ $edition->title() }}
 
                                 <span class="text-right pull-right">
-                                    <small>Edit | Download</small>
+                                    <small>
+                                        <a href="/admin/francken-vrij/{{ $edition->getId() }}">Edit</a> |
+                                        <a href="{{ $edition->pdf() }}">Download</a>
+                                    </small>
                                 </span>
                             </h5>
                         </div>

--- a/src/Infrastructure/Http/Views/admin/layout.blade.php
+++ b/src/Infrastructure/Http/Views/admin/layout.blade.php
@@ -59,6 +59,7 @@
             <li><a href="/admin/committee">Committees</a></li>
             <li><a href="/admin/blog">Blog</a></li>
             <li><a href="/admin/activities">Activities</a></li>
+            <li><a href="/admin/francken-vrij">Francken Vrij</a></li>
           </ul>
         </div>
 

--- a/src/Infrastructure/Http/Views/pages/association/francken-vrij.blade.php
+++ b/src/Infrastructure/Http/Views/pages/association/francken-vrij.blade.php
@@ -1,4 +1,5 @@
 @extends('pages.association')
+@inject('franckenVrij', "Francken\Application\FranckenVrij\FranckenVrijRepository")
 
 @section('content')
 
@@ -24,33 +25,21 @@
         </div>
     </div>
 
-  @foreach(range(20, 1, -1) as $i)
+  @foreach($franckenVrij->volumes() as $volume)
 
-    <hr class="thin-bar"/>
+      <hr class="thin-bar"/>
 
-    <h2>Jaargang {{ $i }}</h2>
+      <h2>Volume {{ $volume->volume() }}</h2>
 
-    <div class="row" style="text-align: center">
-      <div class="col-sm-4">
-          <a href="http://www.professorfrancken.nl/franckenvrij/{{ $i }}.1.pdf">
-              <img src="http://www.professorfrancken.nl/franckenvrij/webplaatjes/{{ $i }}.1.jpg">
-              <h5>Francken Vrij {{ $i }}.1</h5>
-          </a>
+      <div class="row">
+          @foreach($volume->editions() as $edition)
+              <div class="col-sm-4 text-center">
+                  <a href="{{ $edition->pdf() }}">
+                      <img src="{{ $edition->cover() }}" class="img-responsive center-block">
+                      <h5>{{ $edition->title() }}</h5>
+                  </a>
+              </div>
+          @endforeach
       </div>
-      <div class="col-sm-4">
-          <a href="http://www.professorfrancken.nl/franckenvrij/{{ $i }}.2.pdf">
-              <img src="http://www.professorfrancken.nl/franckenvrij/webplaatjes/{{ $i }}.2.jpg">
-              <h5>Francken Vrij {{ $i }}.2</h5>
-          </a>
-      </div>
-      <div class="col-sm-4">
-          <a href="http://www.professorfrancken.nl/franckenvrij/{{ $i }}.3.pdf">
-              <img src="http://www.professorfrancken.nl/franckenvrij/webplaatjes/{{ $i }}.3.jpg">
-              <h5>Francken Vrij {{ $i }}.3</h5>
-          </a>
-      </div>
-    </div>
-
   @endforeach
-
 @endsection

--- a/src/Infrastructure/Http/routes.php
+++ b/src/Infrastructure/Http/routes.php
@@ -42,6 +42,7 @@ Route::group(['middleware' => ['web']], function () {
         Route::get('francken-vrij', 'Admin\FranckenVrijController@index');
         Route::get('francken-vrij/{edition}', 'Admin\FranckenVrijController@edit');
         Route::put('francken-vrij/{edition}', 'Admin\FranckenVrijController@update');
+        Route::delete('francken-vrij/{edition}', 'Admin\FranckenVrijController@destroy');
         Route::post('francken-vrij', 'Admin\FranckenVrijController@store');
     });
 

--- a/src/Infrastructure/Http/routes.php
+++ b/src/Infrastructure/Http/routes.php
@@ -40,6 +40,8 @@ Route::group(['middleware' => ['web']], function () {
 
         // Francken Vrij
         Route::get('francken-vrij', 'Admin\FranckenVrijController@index');
+        Route::get('francken-vrij/{edition}', 'Admin\FranckenVrijController@edit');
+        Route::put('francken-vrij/{edition}', 'Admin\FranckenVrijController@update');
         Route::post('francken-vrij', 'Admin\FranckenVrijController@store');
     });
 

--- a/src/Infrastructure/Http/routes.php
+++ b/src/Infrastructure/Http/routes.php
@@ -37,6 +37,10 @@ Route::group(['middleware' => ['web']], function () {
 
         Route::get('registration-requests', 'Admin\RegistrationRequestsController@index');
         Route::get('registration-requests/{requestId}', 'Admin\RegistrationRequestsController@show');
+
+        // Francken Vrij
+        Route::get('francken-vrij', 'Admin\FranckenVrijController@index');
+        Route::post('francken-vrij', 'Admin\FranckenVrijController@store');
     });
 
     Route::get('{page}', 'MainContentController@page')->where('page', '.+');

--- a/tests/Features/FranckenVrijFeature.php
+++ b/tests/Features/FranckenVrijFeature.php
@@ -46,4 +46,55 @@ class FranckenVrijFeature extends TestCase
         $this->seePageIs('/admin/francken-vrij')
             ->see('Clinical');
     }
+
+    /** @test */
+    function changing_a_published_francken_vrij()
+    {
+        $franckenVrij = $this->app->make(FranckenVrijRepository::class);
+        $id = EditionId::generate();
+        $franckenVrij->save(
+            Edition::publish(
+                $id,
+                "Francken Vrij 20.1",
+                20,
+                1,
+                new Url("http://www.professorfrancken.nl/franckenvrij/webplaatjes/20.1.jpg"),
+                new Url("http://www.professorfrancken.nl/franckenvrij/20.1.pdf")
+            )
+        );
+
+        $this->visit("/admin/francken-vrij/{$id}")
+            ->type('Clinical', 'title')
+            ->type(20, 'volume')
+            ->type(1, 'edition')
+            ->press('Update');
+
+        $this->see('Clinical');
+    }
+
+    /** @test */
+    function changing_a_published_francken_vrij_pdf_file()
+    {
+        $franckenVrij = $this->app->make(FranckenVrijRepository::class);
+        $id = EditionId::generate();
+        $franckenVrij->save(
+            Edition::publish(
+                $id,
+                "Francken Vrij 20.1",
+                20,
+                1,
+                new Url("http://www.professorfrancken.nl/franckenvrij/webplaatjes/20.1.jpg"),
+                new Url("http://www.professorfrancken.nl/franckenvrij/20.1.pdf")
+            )
+        );
+
+        $this->visit("/admin/francken-vrij/{$id}")
+            ->type('Clinical', 'title')
+            ->type(20, 'volume')
+            ->type(1, 'edition')
+            ->attach(__DIR__ . '/stubs/20-1.pdf', 'pdf')
+            ->press('Update');
+
+        $this->see('Clinical');
+    }
 }

--- a/tests/Features/FranckenVrijFeature.php
+++ b/tests/Features/FranckenVrijFeature.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Francken\Features;
+
+use Francken\Application\FranckenVrij\Edition;
+use Francken\Application\FranckenVrij\FranckenVrijRepository;
+use Francken\Domain\FranckenVrij\EditionId;
+use Francken\Domain\Url;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+
+class FranckenVrijFeature extends TestCase
+{
+    use DatabaseMigrations;
+
+    /** @test */
+    function a_list_of_all_francken_vrijs_are_displayed()
+    {
+        $franckenVrij = $this->app->make(FranckenVrijRepository::class);
+        $franckenVrij->save(
+            Edition::publish(
+                EditionId::generate(),
+                "Francken Vrij 20.1",
+                20,
+                1,
+                new Url("http://www.professorfrancken.nl/franckenvrij/webplaatjes/20.1.jpg"),
+                new Url("http://www.professorfrancken.nl/franckenvrij/20.1.pdf")
+            )
+        );
+
+        $this->visit('/association/francken-vrij')
+            ->see("Volume 20");
+    }
+
+    /** @test */
+    function publishing_a_new_francken_vrij()
+    {
+        $this->visit('/admin/francken-vrij')
+            ->type('Clinical', 'title')
+            ->type(20, 'volume')
+            ->type(1, 'edition')
+            ->attach(__DIR__ . '/stubs/20-1.pdf', 'pdf')
+            ->press('Publish');
+
+        $this->seePageIs('/admin/francken-vrij')
+            ->see('Clinical');
+    }
+}

--- a/tests/Features/FranckenVrijFeature.php
+++ b/tests/Features/FranckenVrijFeature.php
@@ -97,4 +97,26 @@ class FranckenVrijFeature extends TestCase
 
         $this->see('Clinical');
     }
+
+    /** @test */
+    function removing_a_published_francken_vrij()
+    {
+        $franckenVrij = $this->app->make(FranckenVrijRepository::class);
+        $id = EditionId::generate();
+        $franckenVrij->save(
+            Edition::publish(
+                $id,
+                "Francken Vrij 20.1",
+                20,
+                1,
+                new Url("http://www.professorfrancken.nl/franckenvrij/webplaatjes/20.1.jpg"),
+                new Url("http://www.professorfrancken.nl/franckenvrij/20.1.pdf")
+            )
+        );
+
+        $this->visit("/admin/francken-vrij/{$id}")
+            ->press('Archive');
+
+        $this->dontSee('Clinical');
+    }
 }

--- a/tests/Francken/Application/FranckenVrij/EditionTest.php
+++ b/tests/Francken/Application/FranckenVrij/EditionTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Francken\Tests\Application\FranckenVrij;
+
+use Francken\Application\FranckenVrij\Edition;
+use Francken\Domain\FranckenVrij\EditionId;
+use Francken\Domain\Url;
+use Francken\Tests\Application\ReadModelTestCase as TestCase;
+
+class EditionTest extends TestCase
+{
+    /** @test */
+    function it_has_a_volume_and_edition_number()
+    {
+        $id = EditionId::generate();
+
+        $edition = Edition::publish(
+            $id,
+            'Francken Vrij',
+            20,
+            1,
+            new Url('http://www.professorfrancken.nl/franckenvrij/webplaatjes/20.1.jpg'),
+            new Url('http://www.professorfrancken.nl/franckenvrij/20.1.pdf')
+        );
+
+        $this->assertEquals($id, $edition->getId());
+        $this->assertEquals('Francken Vrij', $edition->title());
+        $this->assertEquals(20, $edition->volume());
+        $this->assertEquals(1, $edition->edition());
+        $this->assertEquals(new Url('http://www.professorfrancken.nl/franckenvrij/20.1.pdf'), $edition->pdf());
+        $this->assertEquals(new Url('http://www.professorfrancken.nl/franckenvrij/webplaatjes/20.1.jpg'), $edition->cover());
+    }
+
+    /**
+     * @dataProvider editionProvider
+     * @test
+     */
+    function the_volume_and_edition_must_be_positive(int $volume, int $edition, bool $throws = false)
+    {
+        $id = EditionId::generate();
+
+        if ($throws) {
+            $this->expectException(\InvalidArgumentException::class);
+        }
+
+        $edition = Edition::publish(
+            $id,
+            'Francken Vrij',
+            $volume,
+            $edition,
+            new Url('http://www.professorfrancken.nl/franckenvrij/webplaatjes/20.1.jpg'),
+            new Url('http://www.professorfrancken.nl/franckenvrij/20.1.pdf')
+        );
+    }
+
+    function editionProvider() : array
+    {
+        return [
+            [1, 1],
+            [-1, 1, true],
+            [0, 1, true],
+            [1, 0, true],
+            [1, -1, true],
+            [1, 4, true],
+        ];
+    }
+
+
+    protected function createInstance()
+    {
+        return Edition::publish(
+            EditionId::generate(),
+            'Francken Vrij',
+            20,
+            1,
+            new Url('http://www.professorfrancken.nl/franckenvrij/20.1.pdf'),
+            new Url('http://www.professorfrancken.nl/franckenvrij/webplaatjes/20.1.jpg')
+        );
+    }
+}

--- a/tests/Francken/Application/FranckenVrij/FranckenvrijRepositoryTest.php
+++ b/tests/Francken/Application/FranckenVrij/FranckenvrijRepositoryTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Francken\Tests\Application\FranckenVrij;
+
+use Francken\Application\FranckenVrij\Edition;
+use Francken\Application\FranckenVrij\FranckenVrijRepository;
+use Francken\Domain\FranckenVrij\EditionId;
+use Francken\Domain\Url;
+use Francken\Infrastructure\Repositories\InMemoryRepository;
+use PHPUnit_Framework_TestCase as TestCase;
+
+class FranckenvrijRepositoryTest extends TestCase
+{
+    /** @test */
+    function it_returns_an_array_of_volumes()
+    {
+        $repo = new FranckenVrijRepository(
+            new InMemoryRepository
+        );
+
+        foreach (range(3, 1, -1) as $volume) {
+            foreach (range(1, 3) as $edition) {
+                $repo->save(
+                    Edition::publish(
+                        EditionId::generate(),
+                        "Francken Vrij " . $volume . '.' . $edition,
+                        $volume,
+                        $edition,
+                        new Url("http://www.professorfrancken.nl/franckenvrij/webplaatjes/{$volume}.{$edition}.jpg"),
+                        new Url("http://www.professorfrancken.nl/franckenvrij/{$volume}.{$edition}.pdf")
+                    )
+                );
+            }
+        }
+
+        $volumes = $repo->volumes();
+
+        $this->assertCount(3, $volumes);
+        $this->assertEquals(2, $volumes[1]->volume());
+        $this->assertCount(3, $volumes[1]->editions());
+    }
+}

--- a/tests/Francken/Application/FranckenVrij/VolumeTest.php
+++ b/tests/Francken/Application/FranckenVrij/VolumeTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Francken\Tests\Application\FranckenVrij;
+
+use Francken\Application\FranckenVrij\Edition;
+use Francken\Application\FranckenVrij\Volume;
+use Francken\Domain\FranckenVrij\EditionId;
+use Francken\Domain\Url;
+use PHPUnit_Framework_TestCase as TestCase;
+
+class VolumeTest extends TestCase
+{
+    private $editions;
+
+    public function setUp()
+    {
+        $this->editions = [
+            Edition::publish(
+                EditionId::generate(),
+                'Francken Vrij',
+                20,
+                1,
+                new Url('http://www.professorfrancken.nl/franckenvrij/webplaatjes/20.1.jpg'),
+                new Url('http://www.professorfrancken.nl/franckenvrij/20.1.pdf')
+            ),
+            Edition::publish(
+                EditionId::generate(),
+                'Francken Vrij',
+                20,
+                2,
+                new Url('http://www.professorfrancken.nl/franckenvrij/webplaatjes/20.2.jpg'),
+                new Url('http://www.professorfrancken.nl/franckenvrij/20.2.pdf')
+            ),
+            Edition::publish(
+                EditionId::generate(),
+                'Francken Vrij',
+                20,
+                3,
+                new Url('http://www.professorfrancken.nl/franckenvrij/webplaatjes/20.3.jpg'),
+                new Url('http://www.professorfrancken.nl/franckenvrij/20.3.pdf')
+            ),
+        ];
+    }
+
+    /** @test */
+    function itisusedasacontainerofeditions()
+    {
+        $volume = new Volume(20, $this->editions);
+        $this->assertEquals(20, $volume->volume());
+        $this->assertEquals($this->editions, $volume->editions());
+    }
+
+    /** @test */
+    function a_volume_cant_contain_editions_that_dont_belong_to_the_same_volume()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $volume = new Volume(21, $this->editions);
+    }
+}

--- a/tests/Francken/Domain/UrlTest.php
+++ b/tests/Francken/Domain/UrlTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Francken\Tests\Domain;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Francken\Domain\Url;
+
+class UrlTest extends TestCase
+{
+    /**
+     * @dataProvider urlProvider
+     * @test
+     */
+    function it_is_constructed_from_a_string_representing_a_url(string $url, bool $throws = false)
+    {
+        if ($throws) {
+            $this->expectException(\InvalidArgumentException::class);
+        }
+
+        $this->assertEquals($url, (string)(new Url($url)));
+    }
+
+    public function urlProvider()
+    {
+        return [
+            ['http://test.com'],
+            ['https://test.com'],
+            ['http://www.test.com'],
+            ['http://www.test.com/test'],
+            ['test.com', true],
+        ];
+    }
+}


### PR DESCRIPTION
This PR adds the option to easily upload new Francken Vrij editions.

Uploading a new edition only requires you te set the title, volume number, edition number and upload the pdf of the Francken Vrij. We will generate a cover image from the first page of the pdf.

Note that sicne generating the cover image requires ImageMagick you may need to update your dev environment if it does not yet have ImageMagick installed.