### PR TITLE
Add title and description meta tags

### DIFF
--- a/resources/views/homepage/homepage.blade.php
+++ b/resources/views/homepage/homepage.blade.php
@@ -1,5 +1,8 @@
 @extends('homepage.layout')
 
+@section('title', "T.F.V. 'Professor Francken'")
+@section('description', "‘Professor Francken’ is the study association for Applied Physics, connected to the University of Groningen. It is named after Groningen’s first professor of Applied Physics and is for students and staff of the applied physics departments.")
+
 @section('main-content')
     @include("homepage._about-francken")
 

--- a/resources/views/homepage/layout.blade.php
+++ b/resources/views/homepage/layout.blade.php
@@ -4,8 +4,9 @@
         <!-- Required meta tags -->
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <title>T.F.V. 'Professor Francken'</title>
 
+        <title>@yield('title', "T.F.V. 'Professor Francken'")</title>
+        <meta name="description" content="@yield('description')" />
 
         @unless(env('APP_ENV') == 'testing')
             @if (request()->exists('red'))
@@ -54,3 +55,7 @@
   </script>
     </body>
 </html>
+
+@section('description')
+‘Professor Francken’ is the study association for Applied Physics, connected to the University of Groningen. It is named after Groningen’s first professor of Applied Physics and is for students and staff of the applied physics departments. It has over 700 members and organizes, among other, field trips in the Netherlands and an annual symposium and a foreign excursion. Various activities, including the introductory activities for first-year students and the Bèta-bedrijvendagen (a career event for science students), are organised in partnership with sister associations. Membership is a must for students with a technical orientation.
+@endsection

--- a/resources/views/pages/career.blade.php
+++ b/resources/views/pages/career.blade.php
@@ -1,6 +1,7 @@
 @extends('homepage.one-column-layout')
 
 @section('header-image-url', '/images/header/oslo.jpg')
+@section('title', "Career - T.F.V. 'Professor Francken'")
 
 @section('content')
   <h1>Career</h1>


### PR DESCRIPTION
On any page a title and description can be set using sections, i.e.:

```
@section('title', "T.F.V. 'Professor Francken'")
@section('description', "It's an association")
```

We may also want to look into adding other meta tags for keywords and specific tags for social networks.