### PR TITLE
Use an inmemory BookDetailsRepository for offline applications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 APP_ENV=local
 APP_DEBUG=true
 APP_KEY=SomeRandomString
+APP_OFFLINE=true
 
 DB_HOST=mysql
 DB_DATABASE=francken

--- a/config/app.php
+++ b/config/app.php
@@ -157,6 +157,7 @@ return [
         Francken\Infrastructure\RouteServiceProvider::class,
         Francken\Infrastructure\NavigationServiceProvider::class,
         Francken\Infrastructure\EventSourcing\EventSourcingServiceProvider::class,
+        Francken\Infrastructure\Books\BooksServiceProvider::class,
 
         /*
          * Third Party Service Providers

--- a/src/Application/Books/AvailableBooksProjector.php
+++ b/src/Application/Books/AvailableBooksProjector.php
@@ -17,7 +17,7 @@ final class AvailableBooksProjector extends Projector
     private $books;
     private $bookDetailRepository;
 
-    public function __construct(AvailableBooksRepository $books, BookDetailsRepositoryI $repo)
+    public function __construct(AvailableBooksRepository $books, BookDetailsRepository $repo)
     {
         $this->bookDetailRepository = $repo;
         $this->books = $books;

--- a/src/Application/Books/BookDetailsRepository.php
+++ b/src/Application/Books/BookDetailsRepository.php
@@ -2,7 +2,7 @@
 
 namespace Francken\Application\Books;
 
-interface BookDetailsRepositoryI
+interface BookDetailsRepository
 {
     public function getByISBN(string $isbn) : BookDetails;
 }

--- a/src/Application/Books/BookTransactionsProjector.php
+++ b/src/Application/Books/BookTransactionsProjector.php
@@ -15,7 +15,7 @@ final class BookTransactionsProjector extends Projector
     private $members;
     private $bookDetailRepository;
 
-    public function __construct(Repository $books, Repository $members, BookDetailsRepositoryI $repo)
+    public function __construct(Repository $books, Repository $members, BookDetailsRepository $repo)
     {
         $this->bookDetailRepository = $repo;
         $this->books = $books;

--- a/src/Infrastructure/AppServiceProvider.php
+++ b/src/Infrastructure/AppServiceProvider.php
@@ -3,9 +3,6 @@
 namespace Francken\Infrastructure;
 
 use Broadway\EventSourcing\EventSourcingRepository;
-use Francken\Application\Books\AvailableBook;
-use Francken\Application\Books\AvailableBooksRepository;
-use Francken\Application\Books\BookDetailsRepositoryI;
 use Francken\Application\Committees\CommitteesList;
 use Francken\Application\Committees\CommitteesListProjector;
 use Francken\Application\Committees\CommitteesListRepository;
@@ -18,8 +15,6 @@ use Francken\Application\ReadModel\MemberList\MemberList;
 use Francken\Application\ReadModel\MemberList\MemberListRepository;
 use Francken\Application\ReadModel\PostList\PostList;
 use Francken\Application\ReadModel\PostList\PostListRepository;
-use Francken\Domain\Books\Book;
-use Francken\Domain\Books\BookRepository;
 use Francken\Domain\Committees\Committee;
 use Francken\Domain\Committees\CommitteeRepository;
 use Francken\Domain\Members\Member;
@@ -28,7 +23,6 @@ use Francken\Domain\Members\Registration\RegistrationRequest;
 use Francken\Domain\Members\Registration\RegistrationRequestRepository;
 use Francken\Domain\Posts\Post;
 use Francken\Domain\Posts\PostRepository;
-use Francken\Infrastructure\Books\BookDetailsRepository;
 use Francken\Infrastructure\EventSourcing\Factory;
 use Francken\Infrastructure\Repositories\IlluminateRepository;
 use Illuminate\Contracts\Foundation\Application;
@@ -42,7 +36,6 @@ final class AppServiceProvider extends ServiceProvider
     // it contains pairs of the repository's class and the associated
     // aggregate's class name
     const EVENT_SOURCED_REPOSITORIES = [
-        [BookRepository::class, Book::class],
         [CommitteeRepository::class, Committee::class],
         [MemberRepository::class, Member::class],
         [PostRepository::class, Post::class],
@@ -68,10 +61,6 @@ final class AppServiceProvider extends ServiceProvider
         [
             RequestStatusRepository::class,
             ['request_status', RequestStatus::class, 'id']
-        ],
-        [
-            AvailableBooksRepository::class,
-            ['available_books', AvailableBook::class, 'id']
         ],
         [
             FranckenVrijRepository::class,
@@ -138,9 +127,6 @@ final class AppServiceProvider extends ServiceProvider
                     }
                 );
         }
-
-        // Responsible for getting the book cover from Amazon
-        $this->app->bind(BookDetailsRepositoryI::class, BookDetailsRepository::class);
 
         $this->app->bind(ReadModelRepository::class, \Francken\Infrastructure\Repositories\InMemoryRepository::class);
 

--- a/src/Infrastructure/Books/AmazonBookDetailsRepository.php
+++ b/src/Infrastructure/Books/AmazonBookDetailsRepository.php
@@ -3,9 +3,9 @@
 namespace Francken\Infrastructure\Books;
 
 use Francken\Application\Books\BookDetails;
-use Francken\Application\Books\BookDetailsRepositoryI;
+use Francken\Application\Books\BookDetailsRepository;
 
-class BookDetailsRepository implements BookDetailsRepositoryI
+class AmazonBookDetailsRepository implements BookDetailsRepository
 {
     public function getByISBN(string $isbn) : BookDetails
     {

--- a/src/Infrastructure/Books/BooksServiceProvider.php
+++ b/src/Infrastructure/Books/BooksServiceProvider.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Francken\Infrastructure\Books;
+
+use Broadway\EventSourcing\EventSourcingRepository;
+use Francken\Application\Books\AvailableBook;
+use Francken\Application\Books\AvailableBooksRepository;
+use Francken\Application\Books\BookDetailsRepository;
+use Francken\Domain\Books\Book;
+use Francken\Domain\Books\BookRepository;
+use Francken\Infrastructure\Books\AmazonBookDetailsRepository;
+use Francken\Infrastructure\Books\InMemoryBookDetailsRepository;
+use Francken\Infrastructure\EventSourcing\Factory;
+use Francken\Infrastructure\Repositories\IlluminateRepository;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Database\ConnectionInterface as DatabaseConnection;
+use Illuminate\Support\ServiceProvider;
+
+final class BooksServiceProvider extends ServiceProvider
+{
+    /**
+     * Register any application services.
+     */
+    public function register()
+    {
+        $this->registerRepository(BookRepository::class, Book::class);
+
+        // Register read model repositories and other associated services
+        $this->registerReadModels();
+    }
+
+    /**
+     * Register the repositorie used to store our event sourced aggregate root
+     * Currently all repositories use the same configuration based on the
+     * Francken\Infrastructure\EventSourcing\Factory class
+     *
+     * @param string $repository classname
+     * @param string $aggregate  classname
+     */
+    private function registerRepository(string $repository, string $aggregate)
+    {
+        $this->app->when($repository)
+            ->needs(EventSourcingRepository::class)
+            ->give(function (Application $app) use ($aggregate) {
+                $factory = $app->make(Factory::class);
+
+                return $factory->buildForAggregate($aggregate);
+            });
+    }
+
+    /**
+     * Register bindings to get specific Illuminate repositories for our read models
+     */
+    private function registerReadModels()
+    {
+        $this->app->when(AvailableBooksRepository::class)
+            ->needs(ReadModelRepository::class)
+            ->give(
+                function (Application $app) {
+                    return new IlluminateRepository(
+                        $app->make(DatabaseConnection::class),
+                        'available_books',
+                        AvailableBook::class,
+                        'id'
+                    );
+                }
+            );
+
+        // Responsible for getting the book cover from Amazon
+        if ( ! env('APP_OFFLINE', true)) {
+            $this->app->bind(BookDetailsRepository::class, AmazonBookDetailsRepository::class);
+        } else {
+            // If we want our app to stay offline, we will use an inmemory type of BookDetailsRepository
+            $books = [
+                '0691157243' => ['title' => 'Welcome to the Universe', 'author' => 'Neil De Grasse Tyson'],
+                '1603580557' => ['title' => 'Thinking in Systems', 'author' => 'Donella H. Maedows'],
+                '0521198119' => ['title' => 'An introduction to mechanics', 'author' => 'Daniel Kleppner and Robert Kolenkow']
+            ];
+
+            $this->app->instance(
+                BookDetailsRepository::class,
+                new InMemoryBookDetailsRepository($books)
+            );
+        }
+    }
+}

--- a/src/Infrastructure/Books/InMemoryBookDetailsRepository.php
+++ b/src/Infrastructure/Books/InMemoryBookDetailsRepository.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Francken\Infrastructure\Books;
+
+use Francken\Application\Books\BookDetails;
+use Francken\Application\Books\BookDetailsRepository;
+
+final class InMemoryBookDetailsRepository implements BookDetailsRepository
+{
+    private $isbns = [];
+
+    public function __construct(array $books = [])
+    {
+        $this->isbns = $books;
+    }
+    public function getByISBN(string $isbn) : BookDetails
+    {
+        $book = $this->isbns[$isbn] ?? ['title' => 'unkown', 'author' => 'John & Jane Doe'];
+
+        return new BookDetails(
+            $book['title'],
+            $book['author'],
+            'http://images.amazon.com/images/P/' . $isbn . '.jpg'
+        );
+    }
+}

--- a/tests/Francken/Application/Books/AvailableBooksProjectorTest.php
+++ b/tests/Francken/Application/Books/AvailableBooksProjectorTest.php
@@ -8,7 +8,7 @@ use Francken\Application\Books\AvailableBook;
 use Francken\Application\Books\AvailableBooksProjector;
 use Francken\Application\Books\AvailableBooksRepository;
 use Francken\Application\Books\BookDetails;
-use Francken\Application\Books\BookDetailsRepositoryI;
+use Francken\Application\Books\BookDetailsRepository;
 use Francken\Application\Projector;
 use Francken\Domain\Books\BookId;
 use Francken\Domain\Books\Events\BookOfferRetracted;
@@ -124,13 +124,15 @@ class AvailableBooksProjectorTest extends TestCase
 
     protected function createProjector(InMemoryRepository $repository) : Projector
     {
-        $this->bookDetailRepo = $this->prophesize(BookDetailsRepositoryI::Class);
+        $this->bookDetailRepo = $this->prophesize(BookDetailsRepository::Class);
 
         $this->bookDetailRepo->getByISBN("0534408133")->willReturn(
             new BookDetails(
                 "title",
                 "author",
-                "path_to_cover.jpg"));
+                "path_to_cover.jpg"
+            )
+        );
 
         return new AvailableBooksProjector(
             new AvailableBooksRepository(


### PR DESCRIPTION
The books specific code in the AppServiceProvider has now been placed in
BookServiceProvider, which will use the InMemoryBookDetailsRepository when
the environment variable APP_OFFLINE is set to true.
This was made because the previous provider can only retrieve details once in a
couple of seconds / minutes due to Amazon's throtling of web requests.
We should probably just use a real API for retrieving the details.
The naming of the repositories has been made somewhat more consistent.