### PR TITLE
Update .committee-card__logo

### DIFF
--- a/resources/assets/sass/components/committees.scss
+++ b/resources/assets/sass/components/committees.scss
@@ -32,8 +32,8 @@
 }
 
 .committee-card__logo {
-    max-width: 100%;
-    max-height: 100%;
+    max-width: 75%;
+    max-height: 75%;
     margin: 0em auto;
 
     filter: grayscale(100%);


### PR DESCRIPTION
I think making the logo's a bit smaller adds a lot more white to the page, giving a much cleaner view.