### PR TITLE
Extract Spatie Role and Permission

### DIFF
--- a/config/permission.php
+++ b/config/permission.php
@@ -15,7 +15,7 @@ return [
          * `Spatie\Permission\Contracts\Permission` contract.
          */
 
-        'permission' => Spatie\Permission\Models\Permission::class,
+        'permission' => Francken\Auth\Permission::class,
 
         /*
          * When using the "HasRoles" trait from this package, we need to know which
@@ -26,7 +26,7 @@ return [
          * `Spatie\Permission\Contracts\Role` contract.
          */
 
-        'role' => Spatie\Permission\Models\Role::class,
+        'role' => Francken\Auth\Role::class,
 
     ],
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,6 +4,6 @@ parameters:
         - src
     checkMissingIterableValueType: false
     ignoreErrors:
-        - '#Access to an undefined property Spatie\\Permission\\Models\\Role::\$name.#'
-        - '#Access to an undefined property Spatie\\Permission\\Models\\Role::\$guard_name.#'
+        - '#Access to an undefined property Francken\\Auth\\Role::\$name.#'
+        - '#Access to an undefined property Francken\\Auth\\Role::\$guard_name.#'
         - '#Property .* \(Illuminate\\Support\\Carbon\|null\) does not accept DateTimeImmutable#'

--- a/src/Auth/ChangeRolesListener.php
+++ b/src/Auth/ChangeRolesListener.php
@@ -15,7 +15,6 @@ use Francken\Association\Committees\Committee;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 use Log;
-use Spatie\Permission\Models\Role;
 use UnexpectedValueException;
 
 final class ChangeRolesListener

--- a/src/Auth/Http/Controllers/Admin/AccountPermissionsController.php
+++ b/src/Auth/Http/Controllers/Admin/AccountPermissionsController.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Francken\Auth\Http\Controllers\Admin;
 
 use Francken\Auth\Account;
+use Francken\Auth\Permission;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Spatie\Permission\Models\Permission;
 
 final class AccountPermissionsController
 {

--- a/src/Auth/Http/Controllers/Admin/AccountRolesController.php
+++ b/src/Auth/Http/Controllers/Admin/AccountRolesController.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Francken\Auth\Http\Controllers\Admin;
 
 use Francken\Auth\Account;
+use Francken\Auth\Role;
 use Illuminate\Http\RedirectResponse;
-use Spatie\Permission\Models\Role;
 
 final class AccountRolesController
 {

--- a/src/Auth/Http/Controllers/Admin/AccountsController.php
+++ b/src/Auth/Http/Controllers/Admin/AccountsController.php
@@ -8,14 +8,14 @@ use DB;
 use Francken\Association\LegacyMember;
 use Francken\Auth\Account;
 use Francken\Auth\Mail\NotifyAboutAccountActivation;
+use Francken\Auth\Permission;
+use Francken\Auth\Role;
 use Hash;
 use Illuminate\Contracts\Mail\Mailer;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use Illuminate\View\View;
-use Spatie\Permission\Models\Permission;
-use Spatie\Permission\Models\Role;
 
 final class AccountsController
 {

--- a/src/Auth/Http/Controllers/Admin/RolePermissionsController.php
+++ b/src/Auth/Http/Controllers/Admin/RolePermissionsController.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Francken\Auth\Http\Controllers\Admin;
 
+use Francken\Auth\Permission;
+use Francken\Auth\Role;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Spatie\Permission\Models\Permission;
-use Spatie\Permission\Models\Role;
 
 final class RolePermissionsController
 {

--- a/src/Auth/Http/Controllers/Admin/RolesController.php
+++ b/src/Auth/Http/Controllers/Admin/RolesController.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Francken\Auth\Http\Controllers\Admin;
 
+use Francken\Auth\Permission;
+use Francken\Auth\Role;
 use Illuminate\View\View;
-use Spatie\Permission\Models\Permission;
-use Spatie\Permission\Models\Role;
 
 final class RolesController
 {

--- a/src/Auth/ImportPermissionsFromConfig.php
+++ b/src/Auth/ImportPermissionsFromConfig.php
@@ -6,8 +6,6 @@ namespace Francken\Auth;
 
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Config\Repository;
-use Spatie\Permission\Models\Permission;
-use Spatie\Permission\Models\Role;
 
 /**
  * Check whether there are new permissions in our configuration and add these

--- a/src/Auth/Permission.php
+++ b/src/Auth/Permission.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Francken\Auth;
+
+use Spatie\Permission\Models\Permission as SpatiePermission;
+
+final class Permission extends SpatiePermission
+{
+    protected $guarded = [];
+}

--- a/src/Auth/Role.php
+++ b/src/Auth/Role.php
@@ -11,6 +11,8 @@ use Webmozart\Assert\Assert;
 
 final class Role extends SpatieRole
 {
+    protected $guarded = [];
+
     public static function fromCommittee(Committee $committee) : self
     {
         /** @var Role $role */

--- a/src/Auth/SetupPermissions.php
+++ b/src/Auth/SetupPermissions.php
@@ -7,7 +7,6 @@ namespace Francken\Auth;
 
 use DB;
 use Illuminate\Console\Command;
-use Spatie\Permission\Models\Role;
 use Spatie\Permission\PermissionRegistrar;
 
 /**


### PR DESCRIPTION
This allows us to set the guarded property to an empty array which fixes
some issues we're having while updating the latest laravel security
patch.