### PR TITLE
Nextcloud preparations

### DIFF
--- a/bootstrap/helpers.php
+++ b/bootstrap/helpers.php
@@ -46,6 +46,7 @@ function image(?string $url = '', array $options = [], bool $addAppUrl = false) 
     $options = array_merge(['crop' => '1'], $options);
 
     // Temporary fix
+    $url = str_replace("http://francken.nl.localhost", "http://nginx", $url);
     $url = str_replace("https://professorfrancken.nl", "http://nginx", $url);
 
     switch ($proxy) {

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -104,9 +104,12 @@ services:
     restart: always
     ports:
       - 82:9000
-    command: -enable-url-source -mount /mnt/data
+    command: -enable-url-source -mount /mnt/data -http-cache-ttl 604800
     volumes:
       - ./docker/volumes/fly-images/:/mnt/data
+    environment:
+      - MALLOC_ARENA_MAX=2
+
 
   redis:
     image: redis:4-alpine

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1641,14 +1641,14 @@ parameters:
 			path: src/Association/News/News.php
 
 		-
-			message: "#^Method Francken\\\\Association\\\\Photos\\\\Album\\:\\:coverPhoto\\(\\) return type with generic class Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasOne does not specify its types\\: TRelatedModel$#"
+			message: "#^Method Francken\\\\Association\\\\Photos\\\\FlickrAlbum\\:\\:coverPhoto\\(\\) return type with generic class Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasOne does not specify its types\\: TRelatedModel$#"
 			count: 1
-			path: src/Association/Photos/Album.php
+			path: src/Association/Photos/FlickrAlbum.php
 
 		-
-			message: "#^Method Francken\\\\Association\\\\Photos\\\\Album\\:\\:photos\\(\\) return type with generic class Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany does not specify its types\\: TRelatedModel$#"
+			message: "#^Method Francken\\\\Association\\\\Photos\\\\FlickrAlbum\\:\\:photos\\(\\) return type with generic class Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany does not specify its types\\: TRelatedModel$#"
 			count: 1
-			path: src/Association/Photos/Album.php
+			path: src/Association/Photos/FlickrAlbum.php
 
 		-
 			message: "#^Method Francken\\\\Association\\\\Photos\\\\AlbumsRepository\\:\\:albums\\(\\) return type with generic interface Illuminate\\\\Contracts\\\\Pagination\\\\Paginator does not specify its types\\: TItem$#"
@@ -1716,9 +1716,9 @@ parameters:
 			path: src/Association/Photos/Http/Controllers/AuthenticationController.php
 
 		-
-			message: "#^Method Francken\\\\Association\\\\Photos\\\\Photo\\:\\:album\\(\\) return type with generic class Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\BelongsTo does not specify its types\\: TRelatedModel, TChildModel$#"
+			message: "#^Method Francken\\\\Association\\\\Photos\\\\FlickrPhoto\\:\\:album\\(\\) return type with generic class Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\BelongsTo does not specify its types\\: TRelatedModel, TChildModel$#"
 			count: 1
-			path: src/Association/Photos/Photo.php
+			path: src/Association/Photos/FlickrPhoto.php
 
 		-
 			message: "#^Method Francken\\\\Association\\\\Photos\\\\PhotosAuthentication\\:\\:isLoggedIn\\(\\) should return bool but returns mixed\\.$#"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -392,7 +392,7 @@
   </file>
   <file src="src/Association/Photos/AlbumsRepository.php">
     <InvalidTemplateParam>
-      <code><![CDATA[Album::where('is_public', true)
+      <code><![CDATA[FlickrAlbum::where('is_public', true)
             ->with('coverPhoto')
             ->orderBy('activity_date', 'desc')]]></code>
     </InvalidTemplateParam>

--- a/resources/views/association/photos/index.blade.php
+++ b/resources/views/association/photos/index.blade.php
@@ -30,7 +30,7 @@
     {{ $albums->onEachSide(3)->links() }}
 
     @if (! $albums->hasMorePages())
-        @cannot('view-private-albums')
+        @cannot('view-members-only-albums')
         <div class="card bg-light">
             <div class="card-body">
                 <h3 class="h5">Login to view older albums</h3>

--- a/resources/views/career/index.blade.php
+++ b/resources/views/career/index.blade.php
@@ -36,7 +36,7 @@
         <a href="/career/companies">
             <img
                 alt="Companies related to engineering physics"
-                src="{{ image('/images/company_profiles.jpg', ['height' => 150, 'width' => 150]) }}"
+                src="{{ image('/images/company_profiles.jpg', ['height' => 150, 'width' => 150], true) }}"
                 class="mb-3 rounded-circle"
                 style="height: 150px; width: 150px; object-fit: contain"
             />

--- a/resources/views/pages/association.blade.php
+++ b/resources/views/pages/association.blade.php
@@ -20,7 +20,7 @@
                 <a href="{{ action([\Francken\Association\News\Http\NewsController::class, 'index']) }}">
                     <img
                         alt="News related to Francken and other associations"
-                        src="{{ image('/images/news_images.jpg', ['height' => 150, 'width' => 150]) }}"
+                        src="{{ image('/images/news_images.jpg', ['height' => 150, 'width' => 150], true) }}"
                         class="mb-3 rounded-circle"
                         style="height: 150px; width: 150px; object-fit: contain"
                     />

--- a/resources/views/pages/study.blade.php
+++ b/resources/views/pages/study.blade.php
@@ -58,7 +58,7 @@
             <a href="/study/representation/faculty-council">
                 <img
                     alt="Faculty council of the University of Groningen"
-                    src="{{ image('/images/faculty_council.jpg', ['height' => 150, 'width' => 150]) }}"
+                    src="{{ image('/images/faculty_council.jpg', ['height' => 150, 'width' => 150], true) }}"
                     class="mb-3 rounded-circle"
                 />
 

--- a/src/Association/Photos/AlbumsRepository.php
+++ b/src/Association/Photos/AlbumsRepository.php
@@ -56,7 +56,7 @@ final class AlbumsRepository
     {
         // Check whether the user is either authenticated or authenticated by entering
         // the photos password
-        $authenticated = $this->gate->allows('view-private-albums');
+        $authenticated = $this->gate->allows('view-members-only-albums');
 
         if ( ! $authenticated) {
             $oneYearAgo = (new DateTimeImmutable())->sub(new DateInterval('P1Y'));

--- a/src/Association/Photos/AlbumsRepository.php
+++ b/src/Association/Photos/AlbumsRepository.php
@@ -26,7 +26,7 @@ final class AlbumsRepository
 
     public function albums() : Paginator
     {
-        $query = Album::where('is_public', true)
+        $query = FlickrAlbum::where('is_public', true)
             ->with('coverPhoto')
             ->orderBy('activity_date', 'desc');
 
@@ -35,18 +35,18 @@ final class AlbumsRepository
         return $query->simplePaginate(16);
     }
 
-    public function bySlug(string $albumSlug) : Album
+    public function bySlug(string $albumSlug) : FlickrAlbum
     {
-        $query = Album::where('slug', $albumSlug)
+        $query = FlickrAlbum::where('slug', $albumSlug)
             ->where('is_public', true)
             ->with('photos');
 
         $query = $this->filterPrivateAlbums($query);
 
-        /** @var Album $album */
+        /** @var FlickrAlbum $album */
         $album = $query->firstOrFail();
 
-        Assert::isInstanceOf($album, Album::class);
+        Assert::isInstanceOf($album, FlickrAlbum::class);
 
         return $album;
     }

--- a/src/Association/Photos/FlickrAlbum.php
+++ b/src/Association/Photos/FlickrAlbum.php
@@ -9,8 +9,13 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 
-final class Album extends Model
+final class FlickrAlbum extends Model
 {
+    /**
+     * @var string
+     */
+    protected $table = 'albums';
+
     /**
      * @var string[]
      */
@@ -23,19 +28,21 @@ final class Album extends Model
 
     public function photos() : HasMany
     {
-        return $this->hasMany(Photo::class)
+        return $this->hasMany(FlickrPhoto::class, 'album_id')
             ->orderBy('taken_at')
             ->where('is_public', true);
     }
 
     public function coverPhoto() : HasOne
     {
-        return $this->hasOne(Photo::class, 'id', 'cover_photo');
+        return $this->hasOne(FlickrPhoto::class, 'id', 'cover_photo')->withDefault(function ($x) {
+            return $this->photos()->first()?->toArray() ?? [];
+        });
     }
 
     public function nextAlbum() : ?self
     {
-        /** @var Album|null $album */
+        /** @var FlickrAlbum|null $album */
         $album = self::orderBy('activity_date', 'asc')
             ->where('is_public', true)
             ->where('activity_date', '>', $this->activity_date)
@@ -48,7 +55,7 @@ final class Album extends Model
 
     public function previousAlbum() : ?self
     {
-        /** @var Album|null $album */
+        /** @var FlickrAlbum|null $album */
         $album = self::orderBy('activity_date', 'asc')
             ->where('is_public', true)
             ->where('activity_date', '<', $this->activity_date)

--- a/src/Association/Photos/FlickrPhoto.php
+++ b/src/Association/Photos/FlickrPhoto.php
@@ -48,7 +48,7 @@ use Illuminate\Support\Str;
  * @method static \Illuminate\Database\Eloquent\Builder|\Francken\Association\Photos\Photo whereViews($value)
  * @mixin \Eloquent
  */
-final class Photo extends Model
+final class FlickrPhoto extends Model
 {
     private const SIZES = [
         75 => "_s",
@@ -59,10 +59,14 @@ final class Photo extends Model
         800 => "_c",
         1024 => "_b",
     ];
+    /**
+     * @var string
+     */
+    protected $table = 'photos';
 
     public function album() : BelongsTo
     {
-        return $this->belongsTo(Album::class);
+        return $this->belongsTo(FlickrAlbum::class);
     }
 
     public function src(int $quality = 1024) : string

--- a/src/Association/Photos/Http/Controllers/AdminPhotoAlbumsController.php
+++ b/src/Association/Photos/Http/Controllers/AdminPhotoAlbumsController.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Francken\Association\Photos\Http\Controllers;
 
-use Francken\Association\Photos\Album;
+use Francken\Association\Photos\FlickrAlbum;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\View\View;
@@ -13,7 +13,7 @@ final class AdminPhotoAlbumsController
 {
     public function index() : View
     {
-        $albums = Album::query()
+        $albums = FlickrAlbum::query()
             ->orderBy('activity_date', 'desc')
             ->paginate(40);
 

--- a/src/Association/Photos/PhotosPolicy.php
+++ b/src/Association/Photos/PhotosPolicy.php
@@ -24,12 +24,17 @@ final class PhotosPolicy
 
     public function view(?Account $account) : bool
     {
-        return $this->areAlbumsPublic || $this->viewPrivate($account);
+        return $this->areAlbumsPublic || $this->viewMembersOnly($account);
+    }
+
+    public function viewMembersOnly(?Account $account) : bool
+    {
+        return $this->allowed($account);
     }
 
     public function viewPrivate(?Account $account) : bool
     {
-        return $this->allowed($account);
+        return $account !== null && $account->hasPermissionTo('dashboard:photos-read');
     }
 
     private function allowed(?Account $account = null) : bool

--- a/src/Association/Photos/PhotosServiceProvider.php
+++ b/src/Association/Photos/PhotosServiceProvider.php
@@ -14,6 +14,7 @@ final class PhotosServiceProvider extends ServiceProvider
     public function boot(Gate $gate) : void
     {
         $gate->define('view-albums', [PhotosPolicy::class, 'view']);
+        $gate->define('view-members-only-albums', [PhotosPolicy::class, 'viewMembersOnly']);
         $gate->define('view-private-albums', [PhotosPolicy::class, 'viewPrivate']);
     }
 

--- a/src/Shared/Http/Controllers/Admin/PagesController.php
+++ b/src/Shared/Http/Controllers/Admin/PagesController.php
@@ -59,7 +59,7 @@ final class PagesController
         ]);
     }
 
-    public function store(AdminPageRequest $request, ContentCompiler $compiler, Page $page) : RedirectResponse
+    public function store(AdminPageRequest $request, ContentCompiler $compiler) : RedirectResponse
     {
         $markdown = $compiler->content($request->content());
         Page::create([


### PR DESCRIPTION
This PR makes some preparations for migrating our photos from Filckr to Nextcloud. We will do the migration in a few steps:

1. Update existing code (this PR) and rename the Photo and Album models to FlickrPhoto and FlickrAlbum. We will keep using these models to show the current photos in the `/association/photos` page until the very last step of the migration.
2. Create migrations and crud operations for Nextcloud integration into the admin dashboard.
3. Migrate all existing albums to nextcloud and set them up in the admin dashboard
4. Replace FlickrPhoto and FlickrAlbum by new Photo and Album in the `/association/photos` page
5. Remove old Flickr related code (to be done a few weeks after migration is finished)