### PR TITLE
Add database migrations for new nextcloud based photos

### DIFF
--- a/database/migrations/2023_09_05_185806_create_association_albums_table.php
+++ b/database/migrations/2023_09_05_185806_create_association_albums_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('association_albums', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->text('description');
+
+            $table->date('published_at')->index();
+            $table->string('visibility')->index();
+            $table->string('slug');
+            $table->unique('slug');
+
+            $table->string('disk');
+            $table->string('path');
+
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('association_albums');
+    }
+};

--- a/database/migrations/2023_09_05_185813_create_association_photos_table.php
+++ b/database/migrations/2023_09_05_185813_create_association_photos_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('association_photos', function (Blueprint $table) {
+            $table->id();
+
+            $table->bigInteger('album_id')->unsigned()->nullable();
+            $table->foreign('album_id')->references('id')->on('association_albums');
+
+            $table->string('name')->nullable();
+            $table->string('path');
+            $table->string('visibility')->index();
+
+            $table->softDeletes();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('association_photos');
+    }
+};


### PR DESCRIPTION
We create two migrations that add two new tables to our database. These
will contain the albums and photos.

The album table has a has_many relation with photos.

Below an example can be seen of two filled tables with three albums
where the first album has 2 photos, second has 1 photo and the lunch
lecture album does not yet have any photos.

| id  | title          | description | published_at | visibility   | slug          | disk      | path                             |
|:----|:---------------|:------------|:-------------|:-------------|:--------------|:----------|:---------------------------------|
| xxx | September BBQ  | ...         | 2023-09-09   | members-only | september-bbq | nextcloud | albums/2023-09-09-september-bbq  |
| yyy | Karkaterborrel | ...         | 2023-09-13   | private      | karakterborel | nextcloud | albums/2023-09-13-karakterborrel |
| zzz | Lunch lecture  | ...         | 2023-09-14   | public       | lunch-lecture | nextcloud | albums/2023-09-14-lunch-lecture  |

| id    | album_id | name    | path                                         | visibility   |
|:------|:---------|:--------|:---------------------------------------------|:-------------|
| xxx-1 | xxx      | photo-1 | albums/2023-09-09-september-bbq/photo-1.webp | members-only |
| xxx-2 | xxx      | photo-2 | albums/2023-09-09-september-bbq/photo-2.webp | private      |
| yyy-1 | yyy      | photo-1 | albums/2023-09-13-karakterborel/photo-1.webp | private      |


---


For more information about migrations see [the docs](https://laravel.com/docs/10.x/migrations#main-content) or watch a [laracast](https://laracasts.com/series/laravel-8-from-scratch/episodes/18).
