### PR TITLE
Add nextcloud models

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.14.1@b9d355e0829c397b9b3b47d0c0ed042a8a70284d">
+<files psalm-version="5.15.0@5c774aca4746caf3d239d9c8cadb9f882ca29352">
   <file src="src/Association/Activities/ActivitiesRepository.php">
     <InvalidArgument>
       <code>CalendarEvent::fromEvent($event)</code>
@@ -270,12 +270,6 @@
     </UndefinedMagicPropertyFetch>
   </file>
   <file src="src/Association/Committees/Http/AdminCommitteesController.php">
-    <InvalidArgument>
-      <code><![CDATA[fn (Board $board) : array => [$board->id => $board->board_name->toString()]]]></code>
-    </InvalidArgument>
-    <InvalidTemplateParam>
-      <code><![CDATA[$boards->mapWithKeys(fn (Board $board) : array => [$board->id => $board->board_name->toString()])]]></code>
-    </InvalidTemplateParam>
     <UndefinedMagicPropertyFetch>
       <code><![CDATA[$board->id]]></code>
       <code><![CDATA[$board->id]]></code>
@@ -332,28 +326,6 @@
       <code><![CDATA[[$study->studierichting => $study->studierichting]]]></code>
       <code><![CDATA[[$study->type_lid => $study->type_lid]]]></code>
     </InvalidArrayOffset>
-    <InvalidTemplateParam>
-      <code><![CDATA[LegacyMember::distinct()
-            ->select('studierichting')
-            ->get()
-            ->mapWithKeys(function ($study) {
-                /** @var LegacyMember $study */
-                return [$study->studierichting => $study->studierichting];
-            })]]></code>
-      <code><![CDATA[LegacyMember::distinct()
-            ->select('type_lid')
-            ->get()
-            ->mapWithKeys(function ($study) {
-                /** @var LegacyMember $study */
-                return [$study->type_lid => $study->type_lid];
-            })]]></code>
-    </InvalidTemplateParam>
-    <NullArgument>
-      <code>null</code>
-      <code>null</code>
-      <code>null</code>
-      <code>null</code>
-    </NullArgument>
     <UndefinedMagicPropertyFetch>
       <code><![CDATA[$member->committee->board_id]]></code>
     </UndefinedMagicPropertyFetch>
@@ -390,12 +362,10 @@
       <code><![CDATA[(int)$this->faker->numberBetween(3, 8)]]></code>
     </RedundantCast>
   </file>
-  <file src="src/Association/Photos/AlbumsRepository.php">
-    <InvalidTemplateParam>
-      <code><![CDATA[FlickrAlbum::where('is_public', true)
-            ->with('coverPhoto')
-            ->orderBy('activity_date', 'desc')]]></code>
-    </InvalidTemplateParam>
+  <file src="src/Association/Photos/Photo.php">
+    <TooManyTemplateParams>
+      <code><![CDATA[BelongsTo<Album, Photo>]]></code>
+    </TooManyTemplateParams>
   </file>
   <file src="src/Association/Soundboards/FileUploader.php">
     <UndefinedMagicPropertyAssignment>
@@ -680,28 +650,7 @@
     <InvalidTemplateParam>
       <code><![CDATA[Product::all()
             ->mapWithKeys(fn ($product) => [$product->id => $product->name])]]></code>
-      <code><![CDATA[Product::orderBy('naam')->get()
-            ->mapWithKeys(fn ($product) => [$product->id => $product->name])]]></code>
-      <code><![CDATA[Product::orderBy('naam')->get()
-            ->mapWithKeys(fn ($product) => [$product->id => $product->name])]]></code>
     </InvalidTemplateParam>
-    <NullArgument>
-      <code>null</code>
-      <code>null</code>
-    </NullArgument>
-    <UndefinedPropertyFetch>
-      <code><![CDATA[$product->id]]></code>
-      <code><![CDATA[$product->id]]></code>
-      <code><![CDATA[$product->name]]></code>
-      <code><![CDATA[$product->name]]></code>
-    </UndefinedPropertyFetch>
-  </file>
-  <file src="src/Treasurer/Http/Requests/AdminSearchTransactionsRequest.php">
-    <InvalidReturnStatement>
-      <code><![CDATA[$this->memberId() !== null
-            ? LegacyMember::find($this->memberId())
-            : null]]></code>
-    </InvalidReturnStatement>
   </file>
   <file src="src/Treasurer/Imports/ImportDeductions.php">
     <InvalidArgument>

--- a/src/Association/Photos/Album.php
+++ b/src/Association/Photos/Album.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Francken\Association\Photos;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+final class Album extends Model
+{
+    use SoftDeletes;
+
+    protected $table = 'association_albums';
+
+    /**
+     * @var string[]
+     */
+    protected $dates = [
+        'created_at',
+        'updated_at',
+        'deleted_at',
+        'published_at',
+    ];
+
+    /**
+     * @var string[]
+     */
+    protected $fillable = [
+        'title',
+        'description',
+        'published_at',
+        'visibility',
+
+        'slug',
+        'disk',
+        'path',
+    ];
+
+    /** @return HasMany<Photo> */
+    public function photos() : HasMany
+    {
+        return $this->hasMany(Photo::class);
+    }
+}

--- a/src/Association/Photos/Photo.php
+++ b/src/Association/Photos/Photo.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Francken\Association\Photos;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+final class Photo extends Model
+{
+    use SoftDeletes;
+
+    protected $table = 'association_photos';
+
+    /**
+     * @var string[]
+     */
+    protected $fillable = [
+        'album_id',
+        'name',
+        'path',
+        'visibility',
+    ];
+
+    /**
+     * @var string[]
+     */
+    protected $dates = [
+        'created_at',
+        'updated_at',
+        'deleted_at',
+    ];
+
+    /** @return BelongsTo<Album, Photo> */
+    public function album() : BelongsTo
+    {
+        return $this->belongsTo(Album::class);
+    }
+
+    public function src() : string
+    {
+        return '';
+    }
+
+    public function getIsTallAttribute() : bool
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
Now that we have the database migrations we can add dedicated `Album` and `Photo` models.
These models can be used to access the database records for albums and photos.

Notice that we the `Album` model has a `photos` method with a `HasMany` relation. This Allows us to do stuff like,
```php
// Find the album first album in the database
$album = Album::first();

// Get its photos
$photos = $album->photos;
```

Eloquent will then automatically find all rows from the `association_photos` table that have the same `album_id` as the given album.
Similarly the `Photo` class has a `album` with a `BelonsTo` relation. Which allows us to do things like,
```php
$photo = Photo::first();
$album = $photo->album;
```

In the current implementation the `Photo` class also has two unused `src()` and `getIsTallAttribute` methods.
These will be used later to get the img src for a photo as well as to determine if a photo is tall (via an [accessor](https://laravel.com/docs/10.x/eloquent-mutators#accessors-and-mutators)) which will be used when we visualize the photos in the website.


--

For more information about Laravel's models see [the docs on eloquent](https://laravel.com/docs/10.x/eloquent) or watch a [laracast](https://laracasts.com/series/laravel-8-from-scratch/episodes/19).

This PR also updates the baseline for [psalm](https://psalm.dev/). Feel free to ignore that for now. Essentially this is a tool that helps us verify that our code is correct but our current setup has some issues resulting in false positives.
