### PR TITLE
Nextcloud: Create, show and edit albums

### DIFF
--- a/resources/views/admin/association/photo-albums/_form.blade.php
+++ b/resources/views/admin/association/photo-albums/_form.blade.php
@@ -1,0 +1,20 @@
+<div class="row">
+    <div class="col-12">
+        <x-forms.select name='path' label="Album path"  :options="$albumDirectories" />
+        <x-forms.text name="title" label="Title" />
+        <x-forms.textarea name="description" label="Description" help="The description is used to improve our Google search results. Should be 1 paragraph."/>
+
+        <x-forms.date
+            name="published_at"
+            label="Published at"
+            :value="optional($album->published_at)->format('Y-m-d')"
+        />
+
+        <x-forms.radio-group
+            name='visibility'
+            label="Visibility"
+            :options="['members-only' => 'Members only', 'private' => 'Private', 'public' => 'Public']"
+            help="Setting visibility to private makes the album and its photos no longer visible to users. Members only will make the album and its photos only visible to members that are logged in while public will be visible by anyone."
+        />
+    </div>
+</div>

--- a/resources/views/admin/association/photo-albums/_photo.blade.php
+++ b/resources/views/admin/association/photo-albums/_photo.blade.php
@@ -1,0 +1,54 @@
+<li
+    class="d-flex align-items-center m-0 bg-white rounded photo
+    {{ implode($classes ?? [])  }}
+    {{  ($photo->is_tall) ? 'tall' : '' }}"
+>
+    <a href="{{ $href ?? '#' }}" class="w-100 h-100 photo-link">
+        <img
+            src="{{ $photo->src() }}"
+            class="w-100 h-100 rounded photo-img"
+        >
+    <div class="d-flex justify-content-between rounded text-white p-3 w-100 photo-overlay">
+        <div class="d-flex flex-column">
+        <div>
+            @isset($views)
+            <span>
+                <strong>
+                    {{ $views }}
+                </strong>
+                views
+            </span>
+            @endisset
+            @isset($amount_of_photos)
+            <span>
+                <strong>
+                    {{ $amount_of_photos }}
+                </strong>
+                photos
+            </span>
+            @endisset
+        </div>
+        @isset($title)
+        <strong>
+            {{ $title }}
+        </strong>
+        @endisset
+        </div>
+            @if(isset($show_visibility) && $show_visibility)
+            <span class="float-right">
+                @switch($photo->visibility)
+                    @case('public')
+                        <i class="fas fa-eye"></i>
+                    @break
+                    @case('private')
+                        <i class="fas fa-eye-slash"></i>
+                    @break
+                    @case('members-only')
+                        <i class="fas fa-user-friends"></i>
+                    @break
+                @endswitch
+            </span>
+            @endif
+    </div>
+    </a>
+</li>

--- a/resources/views/admin/association/photo-albums/create.blade.php
+++ b/resources/views/admin/association/photo-albums/create.blade.php
@@ -1,0 +1,25 @@
+@extends('admin.layout')
+@section('page-title', 'Albums / create')
+
+@section('content')
+    <div class="row">
+        <div class="col">
+            <div class="card">
+                {!! Form::model($album, [
+                        'url' => action([\Francken\Association\Photos\Http\Controllers\AdminPhotoAlbumsController::class, 'store']),
+                        'method' => 'post',
+                        ])
+                !!}
+
+                <div class="card-body">
+                    @include('admin.association.photo-albums._form', ['album' => $album])
+
+                </div>
+                <div class="card-footer">
+                    <x-forms.submit>Add album</x-forms.submit>
+                </div>
+                {!! Form::close() !!}
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/admin/association/photo-albums/edit.blade.php
+++ b/resources/views/admin/association/photo-albums/edit.blade.php
@@ -1,0 +1,27 @@
+@extends('admin.layout')
+@section('page-title', 'Photo albums / ' . $album->published_at->format('Y-m-d') . ' / ' . $album->title)
+
+@section('content')
+    <div class="row">
+        <div class="col">
+            <div class="card">
+                {!!
+                       Form::model($album, [
+                           'url' => action(
+                               [\Francken\Association\Photos\Http\Controllers\AdminPhotoAlbumsController::class, 'update'],
+                               ['album' => $album]
+                           ),
+                           'method' => 'PUT',
+                       ])
+                !!}
+                <div class="card-body">
+                    @include('admin.association.photo-albums._form', ['album' => $album])
+                </div>
+                <div class="card-footer">
+                    <x-forms.submit>Save</x-forms.submit>
+                </div>
+                {!! Form::close() !!}
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/admin/association/photo-albums/index.blade.php
+++ b/resources/views/admin/association/photo-albums/index.blade.php
@@ -8,11 +8,31 @@
                 <div class="card-body">
                     <ul class="agenda-list list-unstyled photo-grid">
                         @foreach ($albums as $album)
+                            @include('admin.association.photo-albums._photo', [
+                                'title' => $album->title,
+                                'amount_of_photos' => $album->photos_count,
+                                'photo' => $album->coverPhoto ?? $album->photos()->first(),
+                                'classes' =>  ['shadow m-2 border'],
+                                'href' => action([\Francken\Association\Photos\Http\Controllers\AdminPhotoAlbumsController::class, 'show'], ['album' => $album]),
+                            ])
+                        @endforeach
+                    </ul>
+                </div>
+                @if($albums->hasMorePages())
+                    <div class="card-footer">
+                        {!! $albums->links() !!}
+                    </div>
+                @endif
+            </div>
+            <div class="card">
+                <div class="card-body">
+                    <ul class="agenda-list list-unstyled photo-grid">
+                        @foreach ($flickrAlbums as $album)
                             @include('association.photos._photo', [
                                 'title' => $album->title,
                                 'amount_of_photos' => $album->amount_of_photos,
                                 'views' => $album->views,
-                                'photo' => $album->coverPhoto,
+                                'photo' => $album->coverPhoto ?? $album->photos()->first(),
                                 'classes' =>  ['shadow m-2 border'],
                                 'href' => $album->url(),
                             ])
@@ -20,9 +40,9 @@
                     </ul>
                 </div>
 
-                @if($albums->hasMorePages())
+                @if($flickrAlbums->hasMorePages())
                     <div class="card-footer">
-                        {!! $albums->links() !!}
+                        {!! $flickrAlbums->links() !!}
                     </div>
                 @endif
             </div>
@@ -31,7 +51,13 @@
 @endsection
 
 @section('actions')
-    <div class="d-flex align-items-start">
+    <div class="d-flex align-items-start gap-3">
+        <a href="{{ action([\Francken\Association\Photos\Http\Controllers\AdminPhotoAlbumsController::class, 'create']) }}"
+            class="btn btn-primary"
+        >
+            <i class="fas fa-plus"></i>
+            Create album
+        </a>
         {!! Form::open(['url' => action([\Francken\Association\Photos\Http\Controllers\AdminPhotoAlbumsController::class, 'refresh'])]) !!}
         <button
            class='btn btn-primary'
@@ -42,3 +68,4 @@
         {!! Form::close() !!}
     </div>
 @endsection
+

--- a/resources/views/admin/association/photo-albums/show.blade.php
+++ b/resources/views/admin/association/photo-albums/show.blade.php
@@ -1,0 +1,55 @@
+@extends('admin.layout')
+@section('page-title', 'Photo albums / ' . $album->published_at->format('Y-m-d') . ' / ' . $album->title)
+
+@section('content')
+    <p class="d-flex gap-3 align-items-center">
+        <span>
+            <i class="fas fa-eye"></i>
+            {{ $album->visibility }}
+        </span>
+        <span>
+            <code>
+                {{ $album->path }}
+            </code>
+        </span>
+    </p>
+    <p class="lead">
+        {{ $album->description  }}
+    </p>
+    <div class="row">
+        <div class="col">
+            <div class="card">
+                <div class="card-body">
+
+                    <ul class="agenda-list list-unstyled photo-grid">
+                        @foreach ($photos as $photo)
+                            @include('admin.association.photo-albums._photo', [
+                                'photo' => $photo,
+                                'title' => $photo->name,
+                                'href' => '#',
+                                'show_visibility' => true,
+                            ])
+                        @endforeach
+                    </ul>
+                </div>
+
+                @if($photos->hasMorePages())
+                    <div class="card-footer">
+                        {!! $photos->links() !!}
+                    </div>
+                @endif
+            </div>
+        </div>
+    </div>
+@endsection
+
+@section('actions')
+    <div class="d-flex align-items-start gap-3">
+        <a href="{{ action([\Francken\Association\Photos\Http\Controllers\AdminPhotoAlbumsController::class, 'edit'], ['album' => $album]) }}"
+            class="btn btn-primary"
+        >
+            <i class="fas fa-edit"></i>
+            Edit album
+        </a>
+    </div>
+@endsection

--- a/resources/views/components/forms/radio-group.blade.php
+++ b/resources/views/components/forms/radio-group.blade.php
@@ -1,0 +1,32 @@
+@props([
+    'name',
+    'label',
+    'value' => null,
+    'options' => [],
+    'placeholder' => '',
+    'help' => '',
+])
+
+<x-forms.form-group :name="$name" :label="$label" :help="$help">
+    <div class="d-flex flex-column flex-sm-row align-items-start mt-2">
+        @foreach ($options as $optionName => $label)
+            <div class="form-check mr-3">
+                {!!
+                       Form::radio(
+                           $name,
+                           $optionName,
+                           false,
+                           [
+                               'id' => "{$name}-{$optionName}",
+                               'class' => 'form-check-input',
+                               'required',
+                           ]
+                       )
+                !!}
+                <label class="form-check-label" for="{{ $name  }}-{{ $optionName  }}">
+                    {{ $label  }}
+                </label>
+            </div>
+        @endforeach
+    </div>
+</x-forms.form-group>

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -194,8 +194,17 @@ Route::group(['prefix' => 'association'], function () : void {
         Route::delete('alumni-activity/{alumnus}', [AdminAlumniActivityController::class, 'destroy']);
     });
 
-    Route::get('photo-albums', [AdminPhotoAlbumsController::class, 'index']);
-    Route::post('photo-albums/refresh', [AdminPhotoAlbumsController::class, 'refresh']);
+    Route::group(['middleware' => 'can:dashboard:photos-read'], function () : void {
+        Route::get('photo-albums', [AdminPhotoAlbumsController::class, 'index']);
+        Route::post('photo-albums', [AdminPhotoAlbumsController::class, 'store']);
+        Route::get('photo-albums/create', [AdminPhotoAlbumsController::class, 'create']);
+        Route::get('photo-albums/{album}', [AdminPhotoAlbumsController::class, 'show']);
+        Route::put('photo-albums/{album}', [AdminPhotoAlbumsController::class, 'update']);
+        Route::get('photo-albums/{album}/edit', [AdminPhotoAlbumsController::class, 'edit']);
+
+        Route::post('photo-albums/refresh', [AdminPhotoAlbumsController::class, 'refresh']);
+    });
+
     Route::group(['prefix' => 'symposia'], function () : void {
         Route::group(['middleware' => 'can:dashboard:symposia-write'], function () : void {
             Route::get('/create', [AdminSymposiaController::class, 'create']);

--- a/src/Association/Photos/Http/Controllers/AdminPhotoAlbumsController.php
+++ b/src/Association/Photos/Http/Controllers/AdminPhotoAlbumsController.php
@@ -4,25 +4,108 @@ declare(strict_types=1);
 
 namespace Francken\Association\Photos\Http\Controllers;
 
+use Francken\Association\Photos\Album;
 use Francken\Association\Photos\FlickrAlbum;
+use Francken\Association\Photos\Http\Requests\AdminAlbumRequest;
+use Francken\Association\Photos\Photo;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\View\View;
 
 final class AdminPhotoAlbumsController
 {
+    private const ROOT = 'remote.php/dav/files/compucie/';
+    private const BASE_PATH = 'remote.php/dav/files/compucie/images';
+
     public function index() : View
     {
-        $albums = FlickrAlbum::query()
+        $flickrAlbums = FlickrAlbum::query()
             ->orderBy('activity_date', 'desc')
-            ->paginate(40);
+            ->paginate(10, ['*'], 'flickr');
+
+        $albums = Album::query()
+            ->orderBy('published_at', 'desc')
+            ->withCount('photos')
+            ->paginate(10);
 
         return view('admin.association.photo-albums.index', [
             'albums' => $albums,
+            'flickrAlbums' => $flickrAlbums,
             'breadcrumbs' => [
                 ['url' => action([self::class, 'index']), 'text' => 'Photo albums'],
             ]
         ]);
+    }
+
+    public function create() : View
+    {
+        $album = new Album();
+
+        $albumDirectories = $this->albumDirectories();
+
+
+        return view('admin.association.photo-albums.create', [
+            'album' => $album,
+            'albumDirectories' => $albumDirectories,
+            'breadcrumbs' => [
+                ['url' => action([self::class, 'index']), 'text' => 'Photo albums'],
+                ['url' => action([self::class, 'create']), 'text' => 'Create album'],
+            ]
+        ]);
+    }
+
+    public function show(Album $album) : View
+    {
+        $photos = $album->photos()->paginate(20);
+
+        return view('admin.association.photo-albums.show', [
+            'album' => $album,
+            'photos' => $photos,
+            'breadcrumbs' => [
+                ['url' => action([self::class, 'index']), 'text' => 'Photo albums'],
+                ['url' => action([self::class, 'show'], ['album' => $album]), 'text' => $album->title]
+            ]
+        ]);
+    }
+
+    public function edit(Album $album) : View
+    {
+        $albumDirectories = $this->albumDirectories();
+
+        return view('admin.association.photo-albums.edit', [
+            'album' => $album,
+            'albumDirectories' => $albumDirectories,
+            'breadcrumbs' => [
+                ['url' => action([self::class, 'index']), 'text' => 'Photo albums'],
+                ['url' => action([self::class, 'show'], ['album' => $album]), 'text' => $album->title],
+                ['url' => action([self::class, 'edit'], ['album' => $album]), 'text' => 'Edit'],
+            ]
+        ]);
+    }
+
+    public function store(AdminAlbumRequest $request) : RedirectResponse
+    {
+        $files = collect(\Storage::disk('nextcloud')->files("images/{$request->path()}"));
+        $photos = $files->map(fn ($file) => new Photo([
+            'name' => pathinfo($file, PATHINFO_FILENAME),
+            'path' => str_replace(self::BASE_PATH, '', $file),
+            'visibility' => $request->visibility(),
+        ]));
+
+        $album = Album::create([
+            'title' => $request->title(),
+            'description' => $request->description(),
+            'slug' => $request->slug(),
+            'published_at' => $request->publishedAt(),
+            'visibility' => $request->visibility(),
+
+            'disk' => $request->disk(),
+            'path' => $request->path(),
+        ]);
+        $album->photos()->saveMany($photos);
+
+        return redirect()->action([self::class, 'show'], ['album' => $album]);
     }
 
     public function refresh() : RedirectResponse
@@ -30,5 +113,28 @@ final class AdminPhotoAlbumsController
         Artisan::queue('photos:synchronize');
 
         return redirect()->action([self::class, 'index']);
+    }
+
+    public function update(AdminAlbumRequest $request, Album $album) : RedirectResponse
+    {
+        $album->update([
+            'title' => $request->title(),
+            'description' => $request->description(),
+            'visibility' => $request->visibility(),
+            'published_at' => $request->publishedAt(),
+            'path' => $request->path(),
+        ]);
+
+        return redirect()->action([self::class, 'show'], ['album' => $album]);
+    }
+
+    /** @return Collection<string, string> */
+    private function albumDirectories() : Collection
+    {
+        return collect(\Storage::disk('nextcloud')->directories("images/albums"))
+                          ->filter(fn (string $album) => $album === str_replace(' ', '', $album))
+                          ->map(fn (string $f) : string => str_replace(self::ROOT, '', $f))
+                          ->map(fn (string $f) : string => preg_replace("/^images\//", '/', $f) ?? '')
+                          ->mapWithKeys(fn (string $f) => [$f => $f]);
     }
 }

--- a/src/Association/Photos/Http/Requests/AdminAlbumRequest.php
+++ b/src/Association/Photos/Http/Requests/AdminAlbumRequest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Francken\Association\Photos\Http\Requests;
+
+use DateTimeImmutable;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
+use InvalidArgumentException;
+
+final class AdminAlbumRequest extends FormRequest
+{
+    public function rules() : array
+    {
+        return [
+            // TODO add a custom rule for checking that the path exists in nextcloud
+            // and check that it is a slug
+            'path' => ['required'],
+
+            'title' => ['required', 'min:1'],
+            'description' => ['nullable'],
+            'visibility' => ['required', Rule::in(['private', 'public', 'members-only'])],
+            'published_at' => ['required', 'date_format:Y-m-d'],
+        ];
+    }
+
+    public function path() : string
+    {
+        return $this->string('path')->toString();
+    }
+
+    public function disk() : string
+    {
+        return 'nextcloud';
+    }
+
+    public function title() : string
+    {
+        return $this->string('title')->toString();
+    }
+
+    public function description() : string
+    {
+        return $this->string('description')->toString();
+    }
+
+    public function visibility() : string
+    {
+        return $this->string('visibility', 'members-only')->toString();
+    }
+
+    public function slug() : string
+    {
+        return Str::slug($this->title());
+    }
+
+    public function publishedAt() : DateTimeImmutable
+    {
+        $installedAt =  $this->toDateTimeImmutable(
+            $this->string('published_at')->toString()
+        );
+
+        if ($installedAt === null) {
+            throw new InvalidArgumentException();
+        }
+
+        return $installedAt;
+    }
+
+
+    private function toDateTimeImmutable(?string $input) : ?DateTimeImmutable
+    {
+        if ($input === null) {
+            return null;
+        }
+
+        $dateTime = DateTimeImmutable::createFromFormat('Y-m-d', $input);
+
+        if ($dateTime === false) {
+            return null;
+        }
+
+        return $dateTime;
+    }
+}

--- a/tests/Features/Admin/Association/PhotoAlbumsFeature.php
+++ b/tests/Features/Admin/Association/PhotoAlbumsFeature.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Francken\Features\Admin\Association;
+
+use Francken\Association\Photos\Album;
+use Francken\Association\Photos\Http\Controllers\AdminPhotoAlbumsController;
+use Francken\Features\LoggedInAsAdmin;
+use Francken\Features\TestCase;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Storage;
+
+class PhotoAlbumsFeature extends TestCase
+{
+    use LoggedInAsAdmin;
+    use DatabaseTransactions;
+
+    /** @test */
+    public function it_creates_albums_from_a_nextcloud_filesystem() : void
+    {
+        // Setup
+        $storage = Storage::fake('nextcloud');
+        $storage->makeDirectory('images/albums/test-123');
+        $storage->makeDirectory('images/albums/2023-09-07-bbq');
+        $storage->put('images/albums/2023-09-07-bbq/photo_1.png', 'hoi_1');
+        $storage->put('images/albums/2023-09-07-bbq/photo_2.png', 'hoi_2');
+        $storage->put('images/albums/2023-09-07-bbq/photo_3.png', 'hoi_3');
+
+
+        // Create new BBQ album
+        $this->createBbqAlbum();
+
+        /**  Album $album */
+        $album = Album::latest()->firstOrFail();
+        $this->assertCount(3, $album->photos);
+
+        // Edit album and first photo
+        $this->editBbqAlbum($album);
+        $album->refresh();
+        $this->assertEquals('BBQ day', $album->title);
+        $this->assertEquals('BBQ day', $album->description);
+    }
+
+    private function createBbqAlbum() : void
+    {
+        $this->visit(action([AdminPhotoAlbumsController::class, 'index']))
+            ->see('Photo albums')
+            ->click('Create album')
+            //  TODO
+            ->select('/albums/2023-09-07-bbq', 'path')
+            ->type('BBQ', 'title')
+            ->type('BBQ', 'description')
+            ->type('2023-09-09', 'published_at')
+            ->select('public', 'visibility')
+            ->press('Add album');
+    }
+
+    private function editBbqAlbum(Album $album) : void
+    {
+        $this
+            ->seePageIs(action([AdminPhotoAlbumsController::class, 'show'], ['album' => $album]))
+            ->click('Edit album')
+            ->seePageIs(action([AdminPhotoAlbumsController::class, 'edit'], ['album' => $album]))
+            ->type('BBQ day', 'title')
+            ->type('BBQ day', 'description')
+            ->type('2023-09-10', 'published_at')
+            ->select('private', 'visibility')
+            ->press('Save');
+    }
+}


### PR DESCRIPTION
This is the biggest part of the nextcloud integration changes. Or at least it requires most of the boilerplate changes we need to do in order to allow people to manage albums from the `/admin` pages.

Let's first focus on the `routes/admin.php` file. Here we add 5 new routes,
```php
Route::post('photo-albums', [AdminPhotoAlbumsController::class, 'store']);
Route::get('photo-albums/create', [AdminPhotoAlbumsController::class, 'create']);
Route::get('photo-albums/{album}', [AdminPhotoAlbumsController::class, 'show']);
Route::put('photo-albums/{album}', [AdminPhotoAlbumsController::class, 'update']);
Route::get('photo-albums/{album}/edit', [AdminPhotoAlbumsController::class, 'edit']);
```

These routes are used to create, show and edit an album. Notice that for creating and editing we have two routes `create` and `store` for adding a new album while `edit` and `update` for updating an album.
The `create` and `edit` routes are used when you go to `admin/association/photo-albums/create` or `/admin/association/photo-albums/1/edit` respectively. They provide the user with a form which when submitted will send a request to `POST /admin/association/photo-albums/` or `PUT admin/association/photo-albums/1`.

The `show`, `create` and `edit` routes return a `View`, which renders the associated `show.blade.php`, `create.blade.php` and `edit.blade.php` templates.
The `show` template is used to show the album's properties as well as all of its photos (using the `_photo.blade.php` partial).

The `create` and `edit` templates are setup in a similar way:
1. We setup a layout using the `@extends` and `@section` directives
2. We open a form with an new or exsiting `$album` via `Form::model`, this essentially makes it so that the form inputs will be automatically populated with the model's properties.
   The action used here is either the `store` action or the `update` method of the associated controller.
3. We include the `admin.association.photo-albums._form` template. This allows us to avoid some duplication as both the create and edit forms require the same input fields
4. We add a submit / save button and close the form

Once the user submits their form we send a request to either the `store` or `update` method.
The store method first tries to find all files in nextcloud at the associated path.
Suppose the user selected `albums/2033-06-06-end-of-the-year-bbq` as the path then all photos included in that folder will be found.
We construct `Photo` instances based on these files where we set the name equal to the filename, visibility to the selected visibility that the user provided and set the pathname to `/albums/2033-06-06-end-of-the-year-bbq/_MG_2090.webp`. The latter makes it so that we can easily find the associated file of each `Photo`.

Once we've constructed all `Photo` instance based on these files we create a new album and [attach](https://laravel.com/docs/10.x/eloquent-relationships#the-save-method) it to this new model via `saveMany`, and we're done.
At the end we redirect the user to the show page so that they can see the new album.

The update method essentially sets the title, description, visibilty and publication date of the album to the values provided by the user. There isn't much special about this.

As this PR adds new functionality to the website we will also want to add some automated tests. In our case we mainly prioritize integration tests, these try to mimic the user's interactions in an automated way.
In this case we've written a single test that creates and album, checks that it contains some photos and that we can change its title and description.
By having this test we can be confident that any followup changes will not introduce bugs that won't allow us to create and edit albums.

---

See the following documentation pages for more in depth information:

- Routing: https://laravel.com/docs/10.x/routing#main-content
- Views: https://laravel.com/docs/10.x/views#main-content
- Controllers: https://laravel.com/docs/10.x/controllers
- Requests: https://laravel.com/docs/10.x/requests
- Responses: https://laravel.com/docs/10.x/responses
