### PR TITLE
Nextcloud: remove album

### DIFF
--- a/resources/views/admin/association/photo-albums/show.blade.php
+++ b/resources/views/admin/association/photo-albums/show.blade.php
@@ -41,6 +41,27 @@
             </div>
         </div>
     </div>
+
+    {!!
+           Form::model(
+               $album,
+               [
+                   'url' => action(
+                       [\Francken\Association\Photos\Http\Controllers\AdminPhotoAlbumsController::class, 'destroy'],
+                       ['album' => $album]
+                   ),
+                   'method' => 'post'
+               ]
+           )
+    !!}
+    @method('DELETE')
+    <p class="mt-2 text-muted d-flex align-items-center justify-content-end">
+        Click <button
+                  class="btn btn-text px-1"
+                  onclick='return confirm("Are you sure you want to remove this album?");'
+              >here</button> to remove this album.
+    </p>
+    {!! Form::close() !!}
 @endsection
 
 @section('actions')

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -201,6 +201,7 @@ Route::group(['prefix' => 'association'], function () : void {
         Route::get('photo-albums/{album}', [AdminPhotoAlbumsController::class, 'show']);
         Route::put('photo-albums/{album}', [AdminPhotoAlbumsController::class, 'update']);
         Route::get('photo-albums/{album}/edit', [AdminPhotoAlbumsController::class, 'edit']);
+        Route::delete('photo-albums/{album}', [AdminPhotoAlbumsController::class, 'destroy']);
 
         Route::post('photo-albums/refresh', [AdminPhotoAlbumsController::class, 'refresh']);
     });

--- a/src/Association/Photos/Http/Controllers/AdminPhotoAlbumsController.php
+++ b/src/Association/Photos/Http/Controllers/AdminPhotoAlbumsController.php
@@ -128,6 +128,13 @@ final class AdminPhotoAlbumsController
         return redirect()->action([self::class, 'show'], ['album' => $album]);
     }
 
+    public function destroy(Album $album) : RedirectResponse
+    {
+        $album->delete();
+
+        return redirect()->action([self::class, 'index']);
+    }
+
     /** @return Collection<string, string> */
     private function albumDirectories() : Collection
     {

--- a/tests/Features/Admin/Association/PhotoAlbumsFeature.php
+++ b/tests/Features/Admin/Association/PhotoAlbumsFeature.php
@@ -40,6 +40,11 @@ class PhotoAlbumsFeature extends TestCase
         $album->refresh();
         $this->assertEquals('BBQ day', $album->title);
         $this->assertEquals('BBQ day', $album->description);
+
+        // Remove album
+        $this->removeAlbum($album);
+        $album->refresh();
+        $this->assertNull(Album::find($album->id));
     }
 
     private function createBbqAlbum() : void
@@ -67,5 +72,13 @@ class PhotoAlbumsFeature extends TestCase
             ->type('2023-09-10', 'published_at')
             ->select('private', 'visibility')
             ->press('Save');
+    }
+
+    private function removeAlbum(Album $album) : void
+    {
+        $this
+            ->seePageIs(action([AdminPhotoAlbumsController::class, 'show'], ['album' => $album]))
+            ->press('here')
+            ->seePageIs(action([AdminPhotoAlbumsController::class, 'index']));
     }
 }


### PR DESCRIPTION
This change is relatively simple. With this we allow the user to remove an album if for instance it was added accidentally.

We add a new `Route::delete` endpoint that uses the `AdminPhotoAlbumsController` destroy method. The naming of this is [by convention](https://laravel.com/docs/10.x/controllers#actions-handled-by-resource-controller).
One interesting thing here is that in the `show.blade.php` view we have the following,
```

    {!!
           Form::model(
               $album,
               [
                   'url' => action(
                       [\Francken\Association\Photos\Http\Controllers\AdminPhotoAlbumsController::class, 'destroy'],
                       ['album' => $album]
                   ),
                   'method' => 'post'
               ]
           )
    !!}
    @method('DELETE')
    <p class="mt-2 text-muted d-flex align-items-center justify-content-end">
        Click <button
                  class="btn btn-text px-1"
                  onclick='return confirm("Are you sure you want to remove this album?");'
              >here</button> to remove this album.
    </p>
    {!! Form::close() !!}
```

The `Form` stuff are helpers from the [laravelcollective/html](https://laravelcollective.com/docs/6.x/html) package that makes it easy to create html forms.
Normally HTML forms are only allowed to make `GET` or `POST` requests (see the `method` in the `Form::model` call) however our controller's `destroy` method accepts only the `DELETE` verb.
To circumvent this issue we use blade's [`@method`](https://laravel.com/docs/10.x/blade#method-field) directive which spoofs this method.

Lastly we also add a new part to our integration test that verifies that we can delete an album.
