### PR TITLE
Nextcloud: update photo

### DIFF
--- a/resources/views/admin/association/photo-albums/photos/edit.blade.php
+++ b/resources/views/admin/association/photo-albums/photos/edit.blade.php
@@ -1,0 +1,41 @@
+@extends('admin.layout')
+@section('page-title', 'Photo albums / ' . $album->published_at->format('Y-m-d') . ' / ' . $album->title . ' / Photos / ' . $photo->name . ' / Edit')
+
+@section('content')
+    <div class="row">
+        <div class="col-4">
+            <div class="card">
+                {!!
+                       Form::model($photo, [
+                           'url' => action(
+                               [\Francken\Association\Photos\Http\Controllers\AdminPhotosController::class, 'update'],
+                               ['album' => $album, 'photo' => $photo]
+                           ),
+                           'method' => 'PUT',
+                       ])
+                !!}
+
+                <div class="card-body">
+                    <x-forms.text name="name" label="Name" />
+                    <x-forms.radio-group
+                        name='visibility'
+                        label="Visibility"
+                        :options="['members-only' => 'Members only', 'private' => 'Private', 'public' => 'Public']"
+                        help="Setting visibility to private makes the photo no longer visible to users. Members only will make the photo only visible to members that are logged in while public will be visible by anyone."
+                    />
+                </div>
+                <div class="card-footer">
+                    <x-forms.submit>Update</x-forms.submit>
+                </div>
+                {!! Form::close() !!}
+            </div>
+        </div>
+
+        <div class="col-8">
+            @include('admin.association.photo-albums._photo', ['photo' => $photo, 'href' => $photo->src(),
+            'title' => $photo->name,
+            ])
+        </div>
+
+    </div>
+@endsection

--- a/resources/views/admin/association/photo-albums/show.blade.php
+++ b/resources/views/admin/association/photo-albums/show.blade.php
@@ -26,7 +26,10 @@
                             @include('admin.association.photo-albums._photo', [
                                 'photo' => $photo,
                                 'title' => $photo->name,
-                                'href' => '#',
+                                'href' => action(
+                                    [\Francken\Association\Photos\Http\Controllers\AdminPhotosController::class, 'edit'],
+                                    ['album' => $album, 'photo' => $photo]
+                                ),
                                 'show_visibility' => true,
                             ])
                         @endforeach

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -23,6 +23,7 @@ use Francken\Association\Members\Http\Controllers\Admin\MembersController;
 use Francken\Association\Members\Http\Controllers\Admin\RegistrationRequestsController;
 use Francken\Association\News\Http\AdminNewsController;
 use Francken\Association\Photos\Http\Controllers\AdminPhotoAlbumsController;
+use Francken\Association\Photos\Http\Controllers\AdminPhotosController;
 use Francken\Association\Symposium\Http\AdminSymposiaController;
 use Francken\Association\Symposium\Http\AdminSymposiaMailPreviewController;
 use Francken\Association\Symposium\Http\AdminSymposiumParticipantsController;
@@ -202,6 +203,9 @@ Route::group(['prefix' => 'association'], function () : void {
         Route::put('photo-albums/{album}', [AdminPhotoAlbumsController::class, 'update']);
         Route::get('photo-albums/{album}/edit', [AdminPhotoAlbumsController::class, 'edit']);
         Route::delete('photo-albums/{album}', [AdminPhotoAlbumsController::class, 'destroy']);
+
+        Route::get('photo-albums/{album}/photos/{photo}/edit', [AdminPhotosController::class, 'edit']);
+        Route::put('photo-albums/{album}/photos/{photo}', [AdminPhotosController::class, 'update']);
 
         Route::post('photo-albums/refresh', [AdminPhotoAlbumsController::class, 'refresh']);
     });

--- a/src/Association/Photos/Http/Controllers/AdminPhotosController.php
+++ b/src/Association/Photos/Http/Controllers/AdminPhotosController.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Francken\Association\Photos\Http\Controllers;
+
+use Francken\Association\Photos\Album;
+use Francken\Association\Photos\Http\Requests\AdminPhotoRequest;
+use Francken\Association\Photos\Photo;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\View\View;
+
+final class AdminPhotosController
+{
+    public function edit(Album $album, Photo $photo) : View
+    {
+        return view('admin.association.photo-albums.photos.edit', [
+            'album' => $album,
+            'photo' => $photo,
+            'breadcrumbs' => [
+                ['url' => action([AdminPhotoAlbumsController::class, 'index']), 'text' => 'Photo albums'],
+                ['url' => action([AdminPhotoAlbumsController::class, 'show'], ['album' => $album]), 'text' => $album->title],
+                ['url' => action([self::class, 'edit'], ['album' => $album, 'photo' => $photo]), 'text' => "Photos / {$photo->name} / Edit"],
+            ]
+        ]);
+    }
+
+    public function update(AdminPhotoRequest $request, Album $album, Photo $photo) : RedirectResponse
+    {
+        $photo->update([
+            'name' => $request->name(),
+            'visibility' => $request->visibility(),
+        ]);
+        // TODO
+
+        return redirect()->action([AdminPhotoAlbumsController::class, 'show'], ['album' => $album]);
+    }
+}

--- a/src/Association/Photos/Http/Requests/AdminPhotoRequest.php
+++ b/src/Association/Photos/Http/Requests/AdminPhotoRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Francken\Association\Photos\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+final class AdminPhotoRequest extends FormRequest
+{
+    public function rules() : array
+    {
+        return [
+            'name' => ['required', 'min:1'],
+            'visibility' => ['required', Rule::in(['private', 'public', 'members-only'])],
+        ];
+    }
+
+    public function name() : string
+    {
+        return $this->string('name')->toString();
+    }
+
+    public function visibility() : string
+    {
+        return $this->string('visibility', 'members-only')->toString();
+    }
+}

--- a/tests/Features/Admin/Association/PhotoAlbumsFeature.php
+++ b/tests/Features/Admin/Association/PhotoAlbumsFeature.php
@@ -6,6 +6,8 @@ namespace Francken\Features\Admin\Association;
 
 use Francken\Association\Photos\Album;
 use Francken\Association\Photos\Http\Controllers\AdminPhotoAlbumsController;
+use Francken\Association\Photos\Http\Controllers\AdminPhotosController;
+use Francken\Association\Photos\Photo;
 use Francken\Features\LoggedInAsAdmin;
 use Francken\Features\TestCase;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -41,6 +43,13 @@ class PhotoAlbumsFeature extends TestCase
         $this->assertEquals('BBQ day', $album->title);
         $this->assertEquals('BBQ day', $album->description);
 
+        /**  @var Photo $photo */
+        $photo = $album->photos()->firstOrFail();
+        $this->editPhoto($album, $photo);
+
+        $photo->refresh();
+        $this->assertEquals('Photo 1', $photo->name);
+        $this->assertEquals('private', $photo->visibility);
         // Remove album
         $this->removeAlbum($album);
         $album->refresh();
@@ -72,6 +81,16 @@ class PhotoAlbumsFeature extends TestCase
             ->type('2023-09-10', 'published_at')
             ->select('private', 'visibility')
             ->press('Save');
+    }
+
+    private function editPhoto(Album $album, Photo $photo) : void
+    {
+        $this->click($photo->name)
+            ->seePageIs(action([AdminPhotosController::class, 'edit'], ['album' => $album, 'photo' => $photo]))
+            ->type('Photo 1', 'name')
+            ->select('private', 'visibility')
+            ->press('Update')
+            ->seePageIs(action([AdminPhotoAlbumsController::class, 'show'], ['album' => $album]));
     }
 
     private function removeAlbum(Album $album) : void


### PR DESCRIPTION
We now also allow users to update a photo's visibility or name. This is unlikely to be used much, but useful nonetheless.

Code wise it is pretty much the same as the previous `nextcloud/create-and-edit-albums` pr.
We add two new routes to the `routes/admin.php` file:

- `GET /photo-albums/{album}/photos/{photo}/edit`
- `PUT /photo-albums/{album}/photos/{photo}/edit`

The `GET` route is used to show the HTML form that allows the user to udpate the name and visibility.
The `PUT` route is used for the actual update in the database and will redirect the user to the previous album page.

Similarly to removing an album we use the `@method` directive to spoof the form to make a `PUT` request.

Again we add a new part to the integration test to make sure we can edit photos.
