### PR TITLE
Nextcloud: Allow removing a photo

### DIFF
--- a/resources/views/admin/association/photo-albums/photos/edit.blade.php
+++ b/resources/views/admin/association/photo-albums/photos/edit.blade.php
@@ -38,4 +38,24 @@
         </div>
 
     </div>
+    {!!
+           Form::model(
+               $album,
+               [
+                   'url' => action(
+                       [\Francken\Association\Photos\Http\Controllers\AdminPhotosController::class, 'destroy'],
+                       ['album' => $album, 'photo' => $photo]
+                   ),
+                   'method' => 'post'
+               ]
+           )
+    !!}
+    @method('DELETE')
+    <p class="mt-2 text-muted d-flex align-items-center justify-content-end">
+        Click <button
+                  class="btn btn-text px-1"
+                  onclick='return confirm("Are you sure you want to remove this photo?");'
+              >here</button> to remove this photo.
+    </p>
+    {!! Form::close() !!}
 @endsection

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -206,6 +206,7 @@ Route::group(['prefix' => 'association'], function () : void {
 
         Route::get('photo-albums/{album}/photos/{photo}/edit', [AdminPhotosController::class, 'edit']);
         Route::put('photo-albums/{album}/photos/{photo}', [AdminPhotosController::class, 'update']);
+        Route::delete('photo-albums/{album}/photos/{photo}', [AdminPhotosController::class, 'destroy']);
 
         Route::post('photo-albums/refresh', [AdminPhotoAlbumsController::class, 'refresh']);
     });

--- a/src/Association/Photos/Http/Controllers/AdminPhotosController.php
+++ b/src/Association/Photos/Http/Controllers/AdminPhotosController.php
@@ -35,4 +35,11 @@ final class AdminPhotosController
 
         return redirect()->action([AdminPhotoAlbumsController::class, 'show'], ['album' => $album]);
     }
+
+    public function destroy(Album $album, Photo $photo) : RedirectResponse
+    {
+        $photo->delete();
+
+        return redirect()->action([AdminPhotoAlbumsController::class, 'show'], ['album' => $album]);
+    }
 }

--- a/tests/Features/Admin/Association/PhotoAlbumsFeature.php
+++ b/tests/Features/Admin/Association/PhotoAlbumsFeature.php
@@ -50,6 +50,12 @@ class PhotoAlbumsFeature extends TestCase
         $photo->refresh();
         $this->assertEquals('Photo 1', $photo->name);
         $this->assertEquals('private', $photo->visibility);
+
+        // Remove photo
+        $this->removePhoto($album, $album->photos[1]);
+
+        $album->load('photos');
+        $this->assertCount(2, $album->photos);
         // Remove album
         $this->removeAlbum($album);
         $album->refresh();
@@ -90,6 +96,13 @@ class PhotoAlbumsFeature extends TestCase
             ->type('Photo 1', 'name')
             ->select('private', 'visibility')
             ->press('Update')
+            ->seePageIs(action([AdminPhotoAlbumsController::class, 'show'], ['album' => $album]));
+    }
+
+    private function removePhoto(Album $album, Photo $photo) : void
+    {
+        $this->click($photo->name)
+            ->press('here')
             ->seePageIs(action([AdminPhotoAlbumsController::class, 'show'], ['album' => $album]));
     }
 


### PR DESCRIPTION
This is pretty much the same as the `nextcloud/remove-album` PR. We add a new route that lets the user destroy an photo.
The form for doing this is accessible from the photo's edit page.
