### PR TITLE
Nextcloud: show photo

### DIFF
--- a/database/factories/association/AlbumFactory.php
+++ b/database/factories/association/AlbumFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/* @var $factory \Illuminate\Database\Eloquent\Factory */
+
+use Faker\Generator as Faker;
+use Francken\Association\Photos\Album;
+
+$factory->define(Album::class, function (Faker $faker) {
+    return [
+        'title' => $faker->sentence,
+        'description' => $faker->paragraph,
+        'slug' => $faker->slug,
+        'visibility' => $faker->randomElement([
+            'private', 'public', 'members-only'
+        ]),
+        'published_at' => $faker->dateTimeThisYear,
+        'disk' => 'nextcloud',
+        'path' => '',
+    ];
+});

--- a/database/factories/association/PhotoFactory.php
+++ b/database/factories/association/PhotoFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+/* @var $factory \Illuminate\Database\Eloquent\Factory */
+
+use Faker\Generator as Faker;
+use Francken\Association\Photos\Album;
+use Francken\Association\Photos\Photo;
+
+$factory->define(Photo::class, function (Faker $faker) {
+    return [
+        'album_id' => factory(Album::class),
+        'name' => $faker->name,
+        'path' => '',
+        'visibility' => $faker->randomElement([
+            'private', 'public', 'members-only'
+        ]),
+    ];
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -147,6 +147,8 @@ Route::group(['prefix' => 'association'], function () : void {
     Route::group(['middleware' => ['login-to-view-photos']], function () : void {
         Route::get('photos', [PhotosController::class, 'index']);
         Route::get('photos/{album}', [PhotosController::class, 'show']);
+
+        Route::get('photos/{album}/{photo}', [PhotosController::class, 'showImage'])->scopeBindings();
     });
 
     Route::get('alumni-2022', [AlumniActivityController::class, 'index'])

--- a/src/Association/Photos/Photo.php
+++ b/src/Association/Photos/Photo.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Francken\Association\Photos;
 
+use Francken\Association\Photos\Http\Controllers\PhotosController;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\Gate;
 
 final class Photo extends Model
 {
@@ -36,16 +39,42 @@ final class Photo extends Model
     /** @return BelongsTo<Album, Photo> */
     public function album() : BelongsTo
     {
-        return $this->belongsTo(Album::class);
+        return $this->belongsTo(Album::class, 'album_id');
     }
 
     public function src() : string
     {
-        return '';
+        return action(
+            [PhotosController::class, 'showImage'],
+            ['album' => $this->album_id, 'photo' => $this]
+        );
     }
 
     public function getIsTallAttribute() : bool
     {
         return false;
+    }
+
+    /**
+     * The "booted" method of the model.
+     */
+    protected static function booted() : void
+    {
+        static::addGlobalScope(
+            'view-permission',
+            function (Builder $builder) : void {
+                $visibilities = ['public'];
+
+                if (Gate::allows('view-private-albums')) {
+                    $visibilities[] = 'private';
+                }
+
+                if (Gate::allows('view-members-only-albums')) {
+                    $visibilities[] = 'members-only';
+                }
+
+                $builder->whereIn('visibility', $visibilities);
+            }
+        );
     }
 }

--- a/tests/Features/Admin/Association/PhotosFeature.php
+++ b/tests/Features/Admin/Association/PhotosFeature.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Francken\Features\Admin\Association;
+
+use Francken\Association\Photos\Album;
+use Francken\Association\Photos\Http\Controllers\PhotosController;
+use Francken\Association\Photos\Photo;
+use Francken\Auth\Account;
+use Francken\Features\LoggedInAsAdmin;
+use Francken\Features\TestCase;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
+
+class PhotosFeature extends TestCase
+{
+    use LoggedInAsAdmin;
+    use DatabaseTransactions;
+
+    /**
+     * @test
+     * @dataProvider permissionProvider
+     */
+    public function it_allows_users_to_view_photo_based_on_permissions($account, $visibility, $isAllowed) : void
+    {
+        $photo = $this->setupPhoto($visibility);
+
+        $album = $photo->album;
+
+        switch ($account) {
+            case 'guest': {
+                \Illuminate\Support\Facades\Auth::logout();
+                break;
+            }
+            case 'member': {
+                $account = factory(Account::class)->create();
+                Auth::loginUsingId($account->id);
+                break;
+            }
+            case 'admin': {
+                break;
+            }
+        }
+
+
+
+        if ( ! $isAllowed) {
+            $this->withoutExceptionHandling();
+            $this->expectException(ModelNotFoundException::class);
+        }
+
+        $this->visit(
+            action([PhotosController::class, 'showImage'], ['album' => $album, 'photo' => $photo])
+        );
+
+        if ($isAllowed) {
+            $this->assertResponseOk();
+        }
+    }
+
+    /** @test */
+    public function it_does_not_allow_viewing_a_photo_in_a_different_album() : void
+    {
+        $album = factory(Album::class)->create();
+        $photo = factory(Photo::class)->create([
+            'path' => 'albums/2023-09-07-bbq/photo_1.png'
+        ]);
+
+        $this->withoutExceptionHandling();
+        $this->expectException(ModelNotFoundException::class);
+        $this->visit(
+            action([PhotosController::class, 'showImage'], ['album' => $album, 'photo' => $photo])
+        );
+    }
+
+    public function permissionProvider()
+    {
+        return [
+            // Guests can only see public photos & albums
+            ['guest', 'public', true],
+            ['guest', 'members-only', false],
+            ['guest', 'private', false],
+            // Members can only see public or members-only photos & albums
+            ['member', 'public', true],
+            ['member', 'members-only', true],
+            ['member', 'private', false],
+            // Admins can see any photos & albums
+            ['admin', 'public', true],
+            ['admin', 'members-only', true],
+            ['admin', 'private', true],
+        ];
+    }
+
+    private function setupPhoto(string $visibility) : Photo
+    {
+        $storage = Storage::fake('nextcloud');
+        $storage->makeDirectory('images/albums/2023-09-07-bbq');
+        $storage->put('images/albums/2023-09-07-bbq/photo_1.png', 'hoi_1');
+
+        $album = factory(Album::class)->create([
+            'visibility' => $visibility,
+        ]);
+
+        return factory(Photo::class)->create([
+            'album_id' => $album->id,
+            'path' => 'albums/2023-09-07-bbq/photo_1.png',
+            'visibility' => $visibility,
+        ]);
+    }
+}


### PR DESCRIPTION
So far we've been able to create, update, delete albums as well as update and delete photos.
But if you've paid any attention you've noticed that the screenshots didn't show any actual photos.

This is because the `Photo` model's `src` method was returning an empty string as we didn't have an endpoint yet that returned the image.

To add this functionallity we had to do three things:

- Add a new `showImage` endpoint that returns the image file of the given photo
- Add a global scope that makes it so that only users with permissions can see private / members-only albums & photos.
- Add a test that verifies the latter.

First the `showImage` endpoint. This is defined in the `routes/web.php` file, which is accessible to the public (i.e. you don't need to be logged in to go to that route).
This route takes the `$photo` associated to the url and then uses the [download](https://laravel.com/docs/10.x/filesystem#downloading-files) method on the filesystem adapter to stream the image.
We also add an etag to the response, this makes it easy for the browser to know how long an image should be cached.

Next up is privacy. We don't want creepy people to see our photos. To do this we add a [global scope](https://laravel.com/docs/10.x/eloquent#global-scopes) to both the `Album` and `Photo` model.
These scopes use a [`Gate`](https://laravel.com/docs/10.x/authorization#gates) to verify if the user can see members-only and/or private albums & photos. If they can't then the global scope automatically adds a filter to the database queries to retrieve only the album & photos that the user can see.

As you may notice we also created two new `AlbumFactory` and `PhotoFactory` files. These are helpers that we can use when creating tests. Essentially they allow us to skip some boilerplate (setting up all the relationship data and attributes of models)
