### PR TITLE
Nextcloud: Allow user to change the visibility of all photos

### DIFF
--- a/resources/views/admin/association/photo-albums/_form.blade.php
+++ b/resources/views/admin/association/photo-albums/_form.blade.php
@@ -1,6 +1,10 @@
 <div class="row">
     <div class="col-12">
-        <x-forms.select name='path' label="Album path"  :options="$albumDirectories" />
+        @if (!$album->exists)
+            <x-forms.select name='path' label="Album path"  :options="$albumDirectories" />
+        @else
+            {!! Form::hidden("path", $album->path) !!}
+        @endif
         <x-forms.text name="title" label="Title" />
         <x-forms.textarea name="description" label="Description" help="The description is used to improve our Google search results. Should be 1 paragraph."/>
 
@@ -16,5 +20,12 @@
             :options="['members-only' => 'Members only', 'private' => 'Private', 'public' => 'Public']"
             help="Setting visibility to private makes the album and its photos no longer visible to users. Members only will make the album and its photos only visible to members that are logged in while public will be visible by anyone."
         />
+        @if ($album->exists)
+            <x-forms.checkbox name="update_visibility_of_photos">
+                <x-slot name="label">
+                    Update the visibility of all photos.
+                </x-slot>
+            </x-forms.checkbox>
+        @endif
     </div>
 </div>

--- a/src/Association/Photos/Http/Controllers/AdminPhotoAlbumsController.php
+++ b/src/Association/Photos/Http/Controllers/AdminPhotoAlbumsController.php
@@ -44,7 +44,6 @@ final class AdminPhotoAlbumsController
 
         $albumDirectories = $this->albumDirectories();
 
-
         return view('admin.association.photo-albums.create', [
             'album' => $album,
             'albumDirectories' => $albumDirectories,
@@ -124,6 +123,12 @@ final class AdminPhotoAlbumsController
             'published_at' => $request->publishedAt(),
             'path' => $request->path(),
         ]);
+
+        if ($request->updateVisibilityOfAllPhotos()) {
+            $album->photos()->update([
+                'visibility' => $request->visibility()
+            ]);
+        }
 
         return redirect()->action([self::class, 'show'], ['album' => $album]);
     }

--- a/src/Association/Photos/Http/Requests/AdminAlbumRequest.php
+++ b/src/Association/Photos/Http/Requests/AdminAlbumRequest.php
@@ -51,6 +51,11 @@ final class AdminAlbumRequest extends FormRequest
         return $this->string('visibility', 'members-only')->toString();
     }
 
+    public function updateVisibilityOfAllPhotos() : bool
+    {
+        return $this->input('update_visibility_of_photos') !== null;
+    }
+
     public function slug() : string
     {
         return Str::slug($this->title());

--- a/tests/Features/Admin/Association/PhotoAlbumsFeature.php
+++ b/tests/Features/Admin/Association/PhotoAlbumsFeature.php
@@ -56,6 +56,13 @@ class PhotoAlbumsFeature extends TestCase
 
         $album->load('photos');
         $this->assertCount(2, $album->photos);
+
+        // Update album visibility
+        $this->editAlbumAndPhotoVisibility($album);
+
+        $album->load('photos');
+        $album->photos->each(fn ($photo) => $this->assertEquals('members-only', $photo->visibility));
+
         // Remove album
         $this->removeAlbum($album);
         $album->refresh();
@@ -104,6 +111,17 @@ class PhotoAlbumsFeature extends TestCase
         $this->click($photo->name)
             ->press('here')
             ->seePageIs(action([AdminPhotoAlbumsController::class, 'show'], ['album' => $album]));
+    }
+
+    private function editAlbumAndPhotoVisibility(Album $album) : void
+    {
+        $this
+            ->seePageIs(action([AdminPhotoAlbumsController::class, 'show'], ['album' => $album]))
+            ->click('Edit album')
+            ->seePageIs(action([AdminPhotoAlbumsController::class, 'edit'], ['album' => $album]))
+            ->select('members-only', 'visibility')
+            ->check('update_visibility_of_photos')
+            ->press('Save');
     }
 
     private function removeAlbum(Album $album) : void


### PR DESCRIPTION
An album might have been created with initially `private` as its visibility value, marking all other photos as `private` as well.
A board member or fotocie member can update the album and photo's visibility one at a time but this might be a bit tedious.
This PR adds a new checkbox to the album's edit form that, when checked, makes it so that we update all the album's related photos' visibility to the same visibility.
