### PR TITLE
Nextcloud: Allow user to refresh an album's photos

### DIFF
--- a/resources/views/admin/association/photo-albums/show.blade.php
+++ b/resources/views/admin/association/photo-albums/show.blade.php
@@ -75,5 +75,13 @@
             <i class="fas fa-edit"></i>
             Edit album
         </a>
+        {!! Form::open(['url' => action([\Francken\Association\Photos\Http\Controllers\AdminPhotoAlbumsController::class, 'refreshAlbum'], ['album' => $album])]) !!}
+        <button
+            class='btn btn-primary'
+        >
+            <i class="fas fa-sync"></i>
+            Refresh
+        </button>
+        {!! Form::close() !!}
     </div>
 @endsection

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -201,6 +201,7 @@ Route::group(['prefix' => 'association'], function () : void {
         Route::get('photo-albums/create', [AdminPhotoAlbumsController::class, 'create']);
         Route::get('photo-albums/{album}', [AdminPhotoAlbumsController::class, 'show']);
         Route::put('photo-albums/{album}', [AdminPhotoAlbumsController::class, 'update']);
+        Route::post('photo-albums/{album}/photos/refresh', [AdminPhotoAlbumsController::class, 'refreshAlbum']);
         Route::get('photo-albums/{album}/edit', [AdminPhotoAlbumsController::class, 'edit']);
         Route::delete('photo-albums/{album}', [AdminPhotoAlbumsController::class, 'destroy']);
 

--- a/tests/Features/Admin/Association/PhotoAlbumsFeature.php
+++ b/tests/Features/Admin/Association/PhotoAlbumsFeature.php
@@ -10,6 +10,7 @@ use Francken\Association\Photos\Http\Controllers\AdminPhotosController;
 use Francken\Association\Photos\Photo;
 use Francken\Features\LoggedInAsAdmin;
 use Francken\Features\TestCase;
+use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Storage;
 
@@ -62,6 +63,11 @@ class PhotoAlbumsFeature extends TestCase
 
         $album->load('photos');
         $album->photos->each(fn ($photo) => $this->assertEquals('members-only', $photo->visibility));
+
+        // Refresh album
+        $this->refreshAlbumPhotos($storage);
+        $album->load('photos');
+        $this->assertCount(4, $album->photos);
 
         // Remove album
         $this->removeAlbum($album);
@@ -122,6 +128,13 @@ class PhotoAlbumsFeature extends TestCase
             ->select('members-only', 'visibility')
             ->check('update_visibility_of_photos')
             ->press('Save');
+    }
+
+    private function refreshAlbumPhotos(Filesystem $storage) : void
+    {
+        $storage->put('images/albums/2023-09-07-bbq/photo_4.png', 'hoi_4');
+
+        $this->press('Refresh');
     }
 
     private function removeAlbum(Album $album) : void


### PR DESCRIPTION
Sometimes photos may have been uploaded to nextcloud after we created an album via the admin page. In this case these photos won't be in our database yet so they won't be shown in the albums pages.

This PR adds a new button when you're looking at a album's page in the admin dashboard that when clicked will add any photos from nextcloud that aren't part of the album yet.

**Open**: what should we do with photos that were previously removed? We could skip those or add them back in.
