### PR TITLE
Nextcloud: add direct url to nextcloud

### DIFF
--- a/config/francken/general.php
+++ b/config/francken/general.php
@@ -8,4 +8,6 @@ return [
     'admin_passphrase' => env('ADMIN_PASSPHRASE', 'Bitterballen dibs machine'),
 
     'photos_hash' => env('PHOTOS_HASH', 'Bitterballen photo machine'),
+
+    'nextcloud_host' => env('NEXTCLOUD_HOST', 'https://nextcloud.francken.nl.localhost'),
 ];

--- a/resources/views/admin/association/photo-albums/show.blade.php
+++ b/resources/views/admin/association/photo-albums/show.blade.php
@@ -69,6 +69,12 @@
 
 @section('actions')
     <div class="d-flex align-items-start gap-3">
+        <a href="{{ $album->nextcloudUrl()  }}"
+            class="btn btn-primary"
+        >
+            <i class="fa-solid fa-cloud"></i>
+            Open in nextcloud
+        </a>
         <a href="{{ action([\Francken\Association\Photos\Http\Controllers\AdminPhotoAlbumsController::class, 'edit'], ['album' => $album]) }}"
             class="btn btn-primary"
         >

--- a/src/Association/Photos/Album.php
+++ b/src/Association/Photos/Album.php
@@ -46,6 +46,11 @@ final class Album extends Model
         return $this->hasMany(Photo::class);
     }
 
+    public function nextcloudUrl() : string
+    {
+        return config('francken.general.nextcloud_host') . "/apps/files/?dir=/images/{$this->path}";
+    }
+
     /**
      * The "booted" method of the model.
      */


### PR DESCRIPTION
This PR adds a convenient button that opens the given album's nextcloud page.
