### PR TITLE
Albums by year

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -103,6 +103,10 @@ services:
       - "traefik.backend=francken-web"
       - "traefik.frontend.rule=Host:francken.nl.localhost"
       - "traefik.port=80"
+    networks:
+      default:
+        aliases:
+          - francken.nl.localhost
 
   imaginary:
     image: h2non/imaginary

--- a/resources/views/admin/association/photo-albums/_form.blade.php
+++ b/resources/views/admin/association/photo-albums/_form.blade.php
@@ -12,6 +12,8 @@
             name="published_at"
             label="Published at"
             :value="optional($album->published_at)->format('Y-m-d')"
+            min="{{ $year }}-01-01"
+            max="{{ $year }}-12-31"
         />
 
         <x-forms.radio-group

--- a/resources/views/admin/association/photo-albums/create-empty.blade.php
+++ b/resources/views/admin/association/photo-albums/create-empty.blade.php
@@ -1,0 +1,23 @@
+@extends('admin.layout')
+@section('page-title', 'Albums / create / ' . $year)
+
+@section('content')
+    <div class="row">
+        <div class="col">
+            <div class="card">
+                <div class="card-body">
+                    <h3>No albums found</h3>
+                    <p>
+                        Either nextcloud has no albums for the year {{ $year }} or they've already been imported.
+                        To create a new album take the following steps:
+                    </p>
+                    <ol>
+                        <li>Upload the new album to nextcloud under the <code>images/albums/{{ $year }}</code> folder.</li>
+                        <li>Refresh this page</li>
+                        <li>Rejoice</li>
+                    </ol>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/admin/association/photo-albums/create.blade.php
+++ b/resources/views/admin/association/photo-albums/create.blade.php
@@ -1,5 +1,5 @@
 @extends('admin.layout')
-@section('page-title', 'Albums / create')
+@section('page-title', 'Albums / create / ' . $year)
 
 @section('content')
     <div class="row">
@@ -13,8 +13,8 @@
 
                 <div class="card-body">
                     @include('admin.association.photo-albums._form', ['album' => $album])
-
                 </div>
+
                 <div class="card-footer">
                     <x-forms.submit>Add album</x-forms.submit>
                 </div>

--- a/resources/views/admin/association/photo-albums/index.blade.php
+++ b/resources/views/admin/association/photo-albums/index.blade.php
@@ -9,7 +9,7 @@
                     <ul class="agenda-list list-unstyled photo-grid">
                         @foreach ($albums as $album)
                             @include('admin.association.photo-albums._photo', [
-                                'title' => $album->title,
+                                'title' => "{$album->published_at->format('Y-m-d')} - {$album->title}",
                                 'amount_of_photos' => $album->photos_count,
                                 'photo' => $album->coverPhoto ?? $album->photos()->first(),
                                 'classes' =>  ['shadow m-2 border'],
@@ -29,7 +29,7 @@
                     <ul class="agenda-list list-unstyled photo-grid">
                         @foreach ($flickrAlbums as $album)
                             @include('association.photos._photo', [
-                                'title' => $album->title,
+                                'title' => "$album->title",
                                 'amount_of_photos' => $album->amount_of_photos,
                                 'views' => $album->views,
                                 'photo' => $album->coverPhoto ?? $album->photos()->first(),
@@ -52,7 +52,7 @@
 
 @section('actions')
     <div class="d-flex align-items-start gap-3">
-        <a href="{{ action([\Francken\Association\Photos\Http\Controllers\AdminPhotoAlbumsController::class, 'create']) }}"
+        <a href="{{ action([\Francken\Association\Photos\Http\Controllers\AdminPhotoAlbumsController::class, 'create'], ['year' => $year]) }}"
             class="btn btn-primary"
         >
             <i class="fas fa-plus"></i>

--- a/resources/views/components/forms/date.blade.php
+++ b/resources/views/components/forms/date.blade.php
@@ -6,6 +6,8 @@
     'help' => '',
     'required' => false,
     'disabled' => false,
+    'min' => null,
+    'max' => null,
 ])
 
 <x-forms.form-group :name="$name" :label="$label" :help="$help">
@@ -19,6 +21,8 @@
                    'id' => $name,
                    'required' => $required,
                    'disabled' => $disabled,
+                   'min' => $min,
+                   'max' => $max,
                ]
            )
     !!}

--- a/routes/web.php
+++ b/routes/web.php
@@ -146,7 +146,7 @@ Route::group(['prefix' => 'association'], function () : void {
     Route::post('photos', [AuthenticationController::class, 'store']);
     Route::group(['middleware' => ['login-to-view-photos']], function () : void {
         Route::get('photos', [PhotosController::class, 'index']);
-        Route::get('photos/{album}', [PhotosController::class, 'show']);
+        Route::get('photos/{album:slug}', [PhotosController::class, 'show']);
 
         Route::get('photos/{album}/{photo}', [PhotosController::class, 'showImage'])->scopeBindings();
     });

--- a/src/Association/Photos/Http/Controllers/AdminPhotoAlbumsController.php
+++ b/src/Association/Photos/Http/Controllers/AdminPhotoAlbumsController.php
@@ -118,6 +118,7 @@ final class AdminPhotoAlbumsController
     {
         $album->update([
             'title' => $request->title(),
+            'slug' => $request->slug(),
             'description' => $request->description(),
             'visibility' => $request->visibility(),
             'published_at' => $request->publishedAt(),

--- a/src/Association/Photos/Http/Controllers/AdminPhotoAlbumsController.php
+++ b/src/Association/Photos/Http/Controllers/AdminPhotoAlbumsController.php
@@ -4,13 +4,17 @@ declare(strict_types=1);
 
 namespace Francken\Association\Photos\Http\Controllers;
 
+use Exception;
 use Francken\Association\Photos\Album;
 use Francken\Association\Photos\FlickrAlbum;
 use Francken\Association\Photos\Http\Requests\AdminAlbumRequest;
 use Francken\Association\Photos\Photo;
+use Francken\Shared\Clock\Clock;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\View\View;
 
 final class AdminPhotoAlbumsController
@@ -18,7 +22,7 @@ final class AdminPhotoAlbumsController
     private const ROOT = 'remote.php/dav/files/compucie/';
     private const BASE_PATH = 'remote.php/dav/files/compucie/images';
 
-    public function index() : View
+    public function index(Clock $clock) : View
     {
         $flickrAlbums = FlickrAlbum::query()
             ->orderBy('activity_date', 'desc')
@@ -31,6 +35,7 @@ final class AdminPhotoAlbumsController
 
         return view('admin.association.photo-albums.index', [
             'albums' => $albums,
+            'year' => $clock->now()->format('Y'),
             'flickrAlbums' => $flickrAlbums,
             'breadcrumbs' => [
                 ['url' => action([self::class, 'index']), 'text' => 'Photo albums'],
@@ -38,18 +43,33 @@ final class AdminPhotoAlbumsController
         ]);
     }
 
-    public function create() : View
+    public function create(Request $request, Clock $clock) : View
     {
-        $album = new Album();
+        $year = $request->string('year')->toString();
 
-        $albumDirectories = $this->albumDirectories();
+        if ($year === '') {
+            $year = $clock->now()->format('Y');
+        }
+
+        $albumDirectories = $this->albumDirectories($year);
+
+        if ($albumDirectories->isEmpty()) {
+            return view('admin.association.photo-albums.create-empty', [
+                'year' => $year,
+                'breadcrumbs' => [
+                    ['url' => action([self::class, 'index']), 'text' => 'Photo albums'],
+                    ['url' => action([self::class, 'create'], ['year' => $year]), 'text' => "{$year} / Create album"],
+                ]
+            ]);
+        }
 
         return view('admin.association.photo-albums.create', [
-            'album' => $album,
+            'album' => new Album(),
             'albumDirectories' => $albumDirectories,
+            'year' => $year,
             'breadcrumbs' => [
                 ['url' => action([self::class, 'index']), 'text' => 'Photo albums'],
-                ['url' => action([self::class, 'create']), 'text' => 'Create album'],
+                ['url' => action([self::class, 'create'], ['year' => $year]), 'text' => "{$year} / Create album"],
             ]
         ]);
     }
@@ -70,11 +90,9 @@ final class AdminPhotoAlbumsController
 
     public function edit(Album $album) : View
     {
-        $albumDirectories = $this->albumDirectories();
-
         return view('admin.association.photo-albums.edit', [
             'album' => $album,
-            'albumDirectories' => $albumDirectories,
+            'year' => $album->published_at->format('Y'),
             'breadcrumbs' => [
                 ['url' => action([self::class, 'index']), 'text' => 'Photo albums'],
                 ['url' => action([self::class, 'show'], ['album' => $album]), 'text' => $album->title],
@@ -145,7 +163,7 @@ final class AdminPhotoAlbumsController
     {
         $album->load('photos');
 
-        $files = collect(\Storage::disk('nextcloud')->files("images/{$album->path}"));
+        $files = collect(Storage::disk('nextcloud')->files("images/{$album->path}"));
         $photos = $files->map(fn ($file) => new Photo([
             'name' => pathinfo($file, PATHINFO_FILENAME),
             'path' => str_replace(self::BASE_PATH, '', $file),
@@ -163,12 +181,23 @@ final class AdminPhotoAlbumsController
     }
 
     /** @return Collection<string, string> */
-    private function albumDirectories() : Collection
+    private function albumDirectories(string $year) : Collection
     {
-        return collect(\Storage::disk('nextcloud')->directories("images/albums"))
-                          ->filter(fn (string $album) => $album === str_replace(' ', '', $album))
-                          ->map(fn (string $f) : string => str_replace(self::ROOT, '', $f))
-                          ->map(fn (string $f) : string => preg_replace("/^images\//", '/', $f) ?? '')
-                          ->mapWithKeys(fn (string $f) => [$f => $f]);
+        try {
+            $directories = Storage::disk('nextcloud')->directories("images/albums/{$year}/");
+
+            $albumsForTheSelectedYear = Album::query()->whereYear('published_at', $year)->pluck('path');
+
+            $directories = collect($directories)
+                ->filter(fn (string $album) => $album === str_replace(' ', '', $album))
+                ->map(fn (string $directory) : string => str_replace(self::ROOT, '', $directory))
+                ->map(fn (string $directory) : string => preg_replace("/^images\//", '/', $directory) ?? '')
+                ->reject(fn (string $directory) => $albumsForTheSelectedYear->contains($directory));
+
+            return $directories->mapWithKeys(fn (string $f) => [$f => $f]);
+        } catch (Exception) {
+            // If the d
+            return collect();
+        }
     }
 }

--- a/src/Association/Photos/Http/Requests/AdminAlbumRequest.php
+++ b/src/Association/Photos/Http/Requests/AdminAlbumRequest.php
@@ -58,7 +58,7 @@ final class AdminAlbumRequest extends FormRequest
 
     public function slug() : string
     {
-        return Str::slug($this->title());
+        return Str::slug($this->publishedAt()->format('Y-m-d') . '-' . $this->title());
     }
 
     public function publishedAt() : DateTimeImmutable

--- a/tests/Features/Admin/Association/PhotoAlbumsFeature.php
+++ b/tests/Features/Admin/Association/PhotoAlbumsFeature.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Francken\Features\Admin\Association;
 
+use DateTimeImmutable;
 use Francken\Association\Photos\Album;
 use Francken\Association\Photos\Http\Controllers\AdminPhotoAlbumsController;
 use Francken\Association\Photos\Http\Controllers\AdminPhotosController;
 use Francken\Association\Photos\Photo;
 use Francken\Features\LoggedInAsAdmin;
 use Francken\Features\TestCase;
+use Francken\Shared\Clock\Clock;
+use Francken\Shared\Clock\FrozenClock;
 use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Storage;
@@ -22,13 +25,16 @@ class PhotoAlbumsFeature extends TestCase
     /** @test */
     public function it_creates_albums_from_a_nextcloud_filesystem() : void
     {
+        $clock = new FrozenClock(new DateTimeImmutable('2023-09-09'));
+        $this->app->instance(Clock::class, $clock);
+
         // Setup
         $storage = Storage::fake('nextcloud');
         $storage->makeDirectory('images/albums/test-123');
-        $storage->makeDirectory('images/albums/2023-09-07-bbq');
-        $storage->put('images/albums/2023-09-07-bbq/photo_1.png', 'hoi_1');
-        $storage->put('images/albums/2023-09-07-bbq/photo_2.png', 'hoi_2');
-        $storage->put('images/albums/2023-09-07-bbq/photo_3.png', 'hoi_3');
+        $storage->makeDirectory('images/albums/2023/2023-09-07-bbq');
+        $storage->put('images/albums/2023/2023-09-07-bbq/photo_1.png', 'hoi_1');
+        $storage->put('images/albums/2023/2023-09-07-bbq/photo_2.png', 'hoi_2');
+        $storage->put('images/albums/2023/2023-09-07-bbq/photo_3.png', 'hoi_3');
 
 
         // Create new BBQ album
@@ -83,7 +89,7 @@ class PhotoAlbumsFeature extends TestCase
             ->see('Photo albums')
             ->click('Create album')
             //  TODO
-            ->select('/albums/2023-09-07-bbq', 'path')
+            ->select('/albums/2023/2023-09-07-bbq', 'path')
             ->type('BBQ', 'title')
             ->type('BBQ', 'description')
             ->type('2023-09-09', 'published_at')
@@ -134,7 +140,7 @@ class PhotoAlbumsFeature extends TestCase
 
     private function refreshAlbumPhotos(Filesystem $storage) : void
     {
-        $storage->put('images/albums/2023-09-07-bbq/photo_4.png', 'hoi_4');
+        $storage->put('images/albums/2023/2023-09-07-bbq/photo_4.png', 'hoi_4');
 
         $this->press('Refresh');
     }

--- a/tests/Features/Admin/Association/PhotoAlbumsFeature.php
+++ b/tests/Features/Admin/Association/PhotoAlbumsFeature.php
@@ -36,6 +36,7 @@ class PhotoAlbumsFeature extends TestCase
 
         /**  Album $album */
         $album = Album::latest()->firstOrFail();
+        $this->assertEquals('2023-09-09-bbq', $album->slug);
         $this->assertCount(3, $album->photos);
 
         // Edit album and first photo
@@ -43,6 +44,7 @@ class PhotoAlbumsFeature extends TestCase
         $album->refresh();
         $this->assertEquals('BBQ day', $album->title);
         $this->assertEquals('BBQ day', $album->description);
+        $this->assertEquals('2023-09-10-bbq-day', $album->slug);
 
         /**  @var Photo $photo */
         $photo = $album->photos()->firstOrFail();


### PR DESCRIPTION
This PR makes it so that in nextcloud all albums should first be categorized in a year folder. When creating an album we now choose a year via the urls `?year=2023` search url parameter.
This is then used to pick the directories from nextcloud from that year which allows us to easily filter out any directories that have already been added to the database.