### PR TITLE
Nextcloud: allow setting a cover photo

### DIFF
--- a/database/migrations/2023_10_01_213225_add_cover_photo_id_to_association_albums_table.php
+++ b/database/migrations/2023_10_01_213225_add_cover_photo_id_to_association_albums_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('association_albums', function (Blueprint $table) {
+            $table->bigInteger('cover_photo_id')->unsigned()->nullable();
+            $table->foreign('cover_photo_id')->references('id')->on('association_photos');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('association_albums', function (Blueprint $table) {
+            $table->dropForeign(['cover_photo_id']);
+            $table->dropColumn('cover_photo_id');
+        });
+    }
+};

--- a/database/migrations/2023_10_01_213225_add_cover_photo_id_to_association_albums_table.php
+++ b/database/migrations/2023_10_01_213225_add_cover_photo_id_to_association_albums_table.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -27,7 +28,9 @@ return new class extends Migration
     public function down()
     {
         Schema::table('association_albums', function (Blueprint $table) {
-            $table->dropForeign(['cover_photo_id']);
+            if (DB::getDriverName() !== 'sqlite') {
+                $table->dropForeign(['cover_photo_id']);
+            }
             $table->dropColumn('cover_photo_id');
         });
     }

--- a/resources/views/admin/association/photo-albums/_photo.blade.php
+++ b/resources/views/admin/association/photo-albums/_photo.blade.php
@@ -36,15 +36,21 @@
         </div>
             @if(isset($show_visibility) && $show_visibility)
             <span class="float-right">
+                @isset($is_cover)
+                @if($is_cover)
+                    <i class="fas fa-star" title="This photo is used as the cover photo"></i>
+                @endif
+                @endisset
+
                 @switch($photo->visibility)
                     @case('public')
-                        <i class="fas fa-eye"></i>
+                        <i class="fas fa-eye" title="Public visibility"></i>
                     @break
                     @case('private')
-                        <i class="fas fa-eye-slash"></i>
+                        <i class="fas fa-eye-slash" title="Private visibility"></i>
                     @break
                     @case('members-only')
-                        <i class="fas fa-user-friends"></i>
+                        <i class="fas fa-user-friends" title="Members only visibility"></i>
                     @break
                 @endswitch
             </span>

--- a/resources/views/admin/association/photo-albums/photos/edit.blade.php
+++ b/resources/views/admin/association/photo-albums/photos/edit.blade.php
@@ -59,3 +59,21 @@
     </p>
     {!! Form::close() !!}
 @endsection
+
+@section('actions')
+    <div class="d-flex align-items-start gap-3">
+        <x-forms.form-button
+            class="btn btn-text btn-sm text-muted"
+            method="PUT"
+            :action="action([\Francken\Association\Photos\Http\Controllers\AdminAlbumCoverController::class, 'update'], ['album' => $photo->album])"
+        >
+            {!! Form::hidden('cover_photo_id', $photo->id) !!}
+            @if($photo->album->cover_photo_id === $photo->id)
+                <i class="fas fa-star text-success"></i>
+            @else
+                <i class="fas fa-star"></i>
+            @endif
+            Set as cover photo
+        </x-forms.form-button>
+    </div>
+@endsection

--- a/resources/views/admin/association/photo-albums/show.blade.php
+++ b/resources/views/admin/association/photo-albums/show.blade.php
@@ -31,6 +31,7 @@
                                     ['album' => $album, 'photo' => $photo]
                                 ),
                                 'show_visibility' => true,
+                                'is_cover' => $album->cover_photo_id === $photo->id,
                             ])
                         @endforeach
                     </ul>

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -22,6 +22,7 @@ use Francken\Association\Members\Http\Controllers\Admin\ConsumptionCounterSettin
 use Francken\Association\Members\Http\Controllers\Admin\MembersController;
 use Francken\Association\Members\Http\Controllers\Admin\RegistrationRequestsController;
 use Francken\Association\News\Http\AdminNewsController;
+use Francken\Association\Photos\Http\Controllers\AdminAlbumCoverController;
 use Francken\Association\Photos\Http\Controllers\AdminPhotoAlbumsController;
 use Francken\Association\Photos\Http\Controllers\AdminPhotosController;
 use Francken\Association\Symposium\Http\AdminSymposiaController;
@@ -201,6 +202,7 @@ Route::group(['prefix' => 'association'], function () : void {
         Route::get('photo-albums/create', [AdminPhotoAlbumsController::class, 'create']);
         Route::get('photo-albums/{album}', [AdminPhotoAlbumsController::class, 'show']);
         Route::put('photo-albums/{album}', [AdminPhotoAlbumsController::class, 'update']);
+        Route::put('photo-albums/{album}/cover-photo', [AdminAlbumCoverController::class, 'update']);
         Route::post('photo-albums/{album}/photos/refresh', [AdminPhotoAlbumsController::class, 'refreshAlbum']);
         Route::get('photo-albums/{album}/edit', [AdminPhotoAlbumsController::class, 'edit']);
         Route::delete('photo-albums/{album}', [AdminPhotoAlbumsController::class, 'destroy']);

--- a/src/Association/Photos/Album.php
+++ b/src/Association/Photos/Album.php
@@ -40,6 +40,19 @@ final class Album extends Model
         'slug',
         'disk',
         'path',
+
+        'cover_photo_id'
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'created_at'=> 'datetime',
+        'updated_at'=> 'datetime',
+        'deleted_at'=> 'datetime',
+        'published_at'=> 'datetime',
+        'cover_photo_id' =>  'integer',
     ];
 
     /** @return HasMany<Photo> */
@@ -51,7 +64,9 @@ final class Album extends Model
     /** @return HasOne<Photo> */
     public function coverPhoto() : HasOne
     {
-        return $this->hasOne(Photo::class)->oldestOfMany();
+        return $this->hasOne(Photo::class, 'id', 'cover_photo_id')->withDefault(function ($instance, $parent) {
+            return $parent->photos()->first();
+        });
     }
 
     public function nextAlbum() : ?self

--- a/src/Association/Photos/Http/Controllers/AdminAlbumCoverController.php
+++ b/src/Association/Photos/Http/Controllers/AdminAlbumCoverController.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Francken\Association\Photos\Http\Controllers;
+
+use Francken\Association\Photos\Album;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+final class AdminAlbumCoverController
+{
+    public function update(Request $request, Album $album) : RedirectResponse
+    {
+        $album->update([
+            'cover_photo_id' => $request->integer('cover_photo_id'),
+        ]);
+
+        return redirect()->action([AdminPhotoAlbumsController::class, 'show'], ['album' => $album]);
+    }
+}

--- a/src/Association/Photos/UpdatePhotoMetadata.php
+++ b/src/Association/Photos/UpdatePhotoMetadata.php
@@ -53,7 +53,6 @@ final class UpdatePhotoMetadata extends Command
                 ->orWhere('height', '=', null)
                 ->chunk(100, function ($photos) use ($storagePath) : void {
                     $photos->each(function (Photo $photo) use ($storagePath) : void {
-                        dump($photo->toArray());
                         try {
                             $metadata = $this->getImageMetadata->metadata($storagePath . '/images' . $photo->path);
                             $photo->width = $metadata->width;

--- a/tests/Features/Admin/Association/PhotoAlbumsFeature.php
+++ b/tests/Features/Admin/Association/PhotoAlbumsFeature.php
@@ -54,6 +54,7 @@ class PhotoAlbumsFeature extends TestCase
 
         /**  @var Photo $photo */
         $photo = $album->photos()->firstOrFail();
+        $this->setCoverPhoto($album, $photo);
         $this->editPhoto($album, $photo);
 
         $photo->refresh();
@@ -118,6 +119,17 @@ class PhotoAlbumsFeature extends TestCase
             ->select('private', 'visibility')
             ->press('Update')
             ->seePageIs(action([AdminPhotoAlbumsController::class, 'show'], ['album' => $album]));
+    }
+
+    private function setCoverPhoto(Album $album, Photo $photo) : void
+    {
+        $this->click($photo->name)
+            ->seePageIs(action([AdminPhotosController::class, 'edit'], ['album' => $album, 'photo' => $photo]))
+            ->press('Set as cover photo')
+            ->seePageIs(action([AdminPhotoAlbumsController::class, 'show'], ['album' => $album]));
+
+        $album->refresh();
+        $this->assertEquals($album->coverPhoto->id, $photo->id);
     }
 
     private function removePhoto(Album $album, Photo $photo) : void


### PR DESCRIPTION
Before we would always pick the first uploaded photo as an album's cover photo - which is used in the photos page and as a top photo for an album.
With this PR we also allow to manually pick a photo and select it as the cover photo.