### PR TITLE
Allow setting btw on products

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -981,11 +981,6 @@ parameters:
 			path: src/Association/Members/Http/Controllers/Admin/MembersController.php
 
 		-
-			message: "#^Relation 'partner' is not found in Francken\\\\Extern\\\\Alumnus model\\.$#"
-			count: 1
-			path: src/Association/Members/Http/Controllers/Admin/MembersController.php
-
-		-
 			message: "#^Access to an undefined property Francken\\\\Association\\\\Members\\\\Registration\\\\Registration\\:\\:\\$personal_details\\.$#"
 			count: 1
 			path: src/Association/Members/Http/Controllers/Admin/RegistrationRequestsController.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -388,6 +388,11 @@
       <code><![CDATA[$committee->name]]></code>
     </UndefinedMagicPropertyFetch>
   </file>
+  <file src="src/Extern/Alumnus.php">
+    <TooManyTemplateParams>
+      <code><![CDATA[BelongsTo<Partner, Alumnus>]]></code>
+    </TooManyTemplateParams>
+  </file>
   <file src="src/Extern/Contact.php">
     <UndefinedThisPropertyFetch>
       <code><![CDATA[$this->firstname]]></code>

--- a/resources/views/admin/treasurer/products/_form.blade.php
+++ b/resources/views/admin/treasurer/products/_form.blade.php
@@ -8,6 +8,7 @@
                 </small>
             </x-slot>
         </x-forms.number>
+        <x-forms.number name="btw" label="Btw" />
         <x-forms.select name="category" label="Category" :options="['Beer' => 'Beer', 'Food' => 'Food', 'Soda' => 'Soda']" />
         <x-forms.checkbox name="available" label="Available" />
         <x-forms.text name="position" label="Position" help="Determines the position in the consumption counter" />

--- a/resources/views/admin/treasurer/products/index.blade.php
+++ b/resources/views/admin/treasurer/products/index.blade.php
@@ -101,7 +101,7 @@
                                     </span>
                                 </h4>
 
-                                <p class='mb-0'>
+                                <p class='my-2'>
                                     <span class="font-weight-normal">
                                         &euro;{{ number_format($product->price / 100, 2) }}
                                     </span>
@@ -110,6 +110,11 @@
                                             (Not available)
                                         </small>
                                     @endif
+                                </p>
+                                <p class='mb-0'>
+                                    <span class="font-weight-normal">
+                                        Btw: {{ $product->btw }}
+                                    </span>
                                 </p>
                         </a>
                     </td>

--- a/resources/views/admin/treasurer/products/show.blade.php
+++ b/resources/views/admin/treasurer/products/show.blade.php
@@ -28,6 +28,10 @@
                                 {{ $product->position }}
                             </dd>
                             @endif
+                            <dt>Btw</dt>
+                            <dd>
+                                {{ $product->btw }}
+                            </dd>
                         </dl>
 
                     </div>

--- a/src/Extern/Alumnus.php
+++ b/src/Extern/Alumnus.php
@@ -47,4 +47,10 @@ final class Alumnus extends Model
     {
         return $this->belongsTo(LegacyMember::class, 'member_id');
     }
+
+    /** @return BelongsTo<Partner, Alumnus> */
+    public function partner() : BelongsTo
+    {
+        return $this->belongsTo(Partner::class, 'partner_id');
+    }
 }

--- a/src/Treasurer/Http/Controllers/AdminProductsController.php
+++ b/src/Treasurer/Http/Controllers/AdminProductsController.php
@@ -71,7 +71,7 @@ final class AdminProductsController
             'beschikbaar' => $request->available(),
             'positie' => $request->position(),
             'afbeelding' => '',
-            'btw' => 0.21,
+            'btw' => $request->btw(),
             'eenheden' => 1,
         ]);
 
@@ -116,6 +116,7 @@ final class AdminProductsController
             'categorie' => $request->dutchCategory(),
             'beschikbaar' => $request->available(),
             'positie' => $request->position(),
+            'btw' => $request->btw(),
         ]);
 
         $uploader->uploadPhoto($request->photo, $product);

--- a/src/Treasurer/Http/Requests/AdminProductRequest.php
+++ b/src/Treasurer/Http/Requests/AdminProductRequest.php
@@ -21,6 +21,7 @@ final class AdminProductRequest extends FormRequest
         return [
             'name' => ['required', 'min:1'],
             'price' => ['required', 'integer'],
+            'btw' => ['required', 'numeric'],
             'category' => ['required', 'in:Beer,Food,Soda'],
             'available' => ['nullable', 'boolean'],
             'position' => ['required', 'integer', 'min:1'],
@@ -51,6 +52,11 @@ final class AdminProductRequest extends FormRequest
     public function price() : int
     {
         return (int)$this->input('price');
+    }
+
+    public function btw() : float
+    {
+        return $this->float('btw');
     }
 
     public function position() : int

--- a/src/Treasurer/Product.php
+++ b/src/Treasurer/Product.php
@@ -58,7 +58,8 @@ final class Product extends Model
     protected $casts = [
         'prijs' => 'float',
         'eenheden' => 'integer',
-        'beschikbaar' => 'boolean'
+        'beschikbaar' => 'boolean',
+        'btw' => 'float',
     ];
 
     /**

--- a/tests/Features/Treasurer/ProductsFeature.php
+++ b/tests/Features/Treasurer/ProductsFeature.php
@@ -63,11 +63,12 @@ class ProductsFeature extends TestCase
     public function it_adds_a_new_product() : void
     {
         $this->visit(action([AdminProductsController::class, 'create']))
-             ->type('Hertog Jan', 'name')
-             ->type(133, 'price')
-             ->select('Beer', 'category')
+            ->type('Hertog Jan', 'name')
+            ->type(133, 'price')
+            ->select('Beer', 'category')
             ->check('available')
-             ->type(1, 'position')
+            ->type(1, 'position')
+            ->type(0.21, 'btw')
             ->attach(UploadedFile::fake()->image('hertog.png'), 'photo')
             ->press('Add');
 
@@ -77,6 +78,7 @@ class ProductsFeature extends TestCase
             ->first();
 
         $this->assertEquals(133, $product->price);
+        $this->assertEquals(0.21, $product->btw);
 
         $this->seePageIs(action(
             [AdminProductsController::class, 'show'],


### PR DESCRIPTION
These changes allows the treasuerer to set btw values on products. This was already available in the database but as this wasn't used before it was harcoded to `0.21`.