### PR TITLE
Removed board room number and added BBD

### DIFF
--- a/resources/views/layout/_footer.blade.php
+++ b/resources/views/layout/_footer.blade.php
@@ -1,3 +1,4 @@
+@inject('settings', "Francken\Shared\Settings\Settings")
 <footer class="mt-md-5">
     @if (isset($editPageUrl))
         <div class="container">
@@ -28,9 +29,8 @@
                 <h4 class="footer__header h5 mb-2">Contact</h4>
 
                 <div class="footer__body">
-                    <i class="far fa-envelope text-primary" aria-hidden="true"></i> <a href="malto: board@professorfrancken.nl">board@professorfrancken.nl</a> <br>
-                    <i class="fa fa-phone text-primary" aria-hidden="true"></i> <a href="tel:+31503634978">tel: +31 (0) 50 363 4978</a> <br>
-
+                    <i class="far fa-envelope text-primary" aria-hidden="true"></i> <a href="mailto: board@professorfrancken.nl">board@professorfrancken.nl</a> <br>
+                    <i class="fa fa-phone text-primary" aria-hidden="true"></i> <a href="tel:{{ str_replace(' ', '', $settings->contactNumberOfChair()) }}">{{ $settings->contactNumberOfChair() }}</a> <br>
                     <a href="/contact"><u>More contact info</u></a>
                 </div>
             </div>

--- a/resources/views/pages/contact.blade.php
+++ b/resources/views/pages/contact.blade.php
@@ -28,7 +28,7 @@
 
             <h4>Board</h4>
             <strong>Email</strong>: <a href="mailto:board@professorfrancken.nl">board@professorfrancken.nl</a><br>
-            <strong>Phone</strong>: <a href="tel:+31503634978">+31 (0) 50 363 4978</a>
+            <strong>Phone</strong>: <a href="tel:{{ str_replace(' ', '', $settings->contactNumberOfChair()) }}">{{ $settings->contactNumberOfChair() }}</a>
 
             <h4>External relations</h4>
             <strong>Email</strong>: <a href="mailto:extern@professorfrancken.nl" >extern@professorfrancken.nl</a><br>

--- a/src/Shared/Providers/NavigationServiceProvider.php
+++ b/src/Shared/Providers/NavigationServiceProvider.php
@@ -58,6 +58,14 @@ final class NavigationServiceProvider extends ServiceProvider
                     'icon' => 'building',
                 ];
             }
+            if ($settings->isBBDShownInNavigation()) {
+                $menu[] = [
+                    'url' => 'https://www.betabusinessdays.nl/',
+                    'title' => 'Beta Business Days',
+                    'subItems' => [],
+                    'icon' => 'suitcase',
+                ];
+            }
 
             $account = Auth::user();
             if ($account !== null && $account instanceof Account) {

--- a/src/Shared/Settings/Http/Controllers/SettingsController.php
+++ b/src/Shared/Settings/Http/Controllers/SettingsController.php
@@ -32,6 +32,7 @@ class SettingsController
     {
         $request->validate([
             "number_of_extern" => ['required'],
+            "number_of_chair" => ['required'],
             "header_image" => ['required'],
             "private_albums" => ['required'],
             "navigation_show_login" => ['nullable', 'boolean'],
@@ -39,10 +40,12 @@ class SettingsController
             "navigation_show_symposium" => ['nullable', 'boolean'],
             "navigation_show_pienter" => ['nullable', 'boolean'],
             "navigation_show_expedition" => ['nullable', 'boolean'],
+            "navigation_show_bbd" => ['nullable', 'boolean'],
         ]);
 
         $settings = [
             "number_of_extern" => $request->input("number_of_extern"),
+            "number_of_chair" => $request->input("number_of_chair"),
             "header_image" => $request->input("header_image"),
             "private_albums" => (bool)$request->input("private_albums"),
             "navigation_show_login" => (bool) $request->input("navigation_show_login"),
@@ -50,6 +53,7 @@ class SettingsController
             "navigation_show_symposium" => (bool) $request->input("navigation_show_symposium"),
             "navigation_show_pienter" => (bool) $request->input("navigation_show_pienter"),
             "navigation_show_expedition" => (bool) $request->input("navigation_show_expedition"),
+            "navigation_show_bbd" => (bool) $request->input("navigation_show_bbd"),
         ];
 
         // Make sure that we only pass settings which are expected

--- a/src/Shared/Settings/Settings.php
+++ b/src/Shared/Settings/Settings.php
@@ -12,6 +12,8 @@ interface Settings extends IteratorAggregate
 
     public function contactNumberOfExtern() : string;
 
+    public function contactNumberOfChair() : string;
+
     public function areAlbumsPrivate() : bool;
 
     public function headerImage() : string;
@@ -28,4 +30,6 @@ interface Settings extends IteratorAggregate
     public function isPienterShownInNavigation() : bool;
 
     public function isExpeditionShownInNavigation() : bool;
+
+    public function isBBDShownInNavigation() : bool;
 }

--- a/src/Shared/Settings/ValueStoreSettings.php
+++ b/src/Shared/Settings/ValueStoreSettings.php
@@ -17,6 +17,10 @@ final class ValueStoreSettings implements Settings
      */
     private const NUMBER_OF_EXTERN = 'number_of_extern';
     /**
+     *  @var string
+     */
+    private const NUMBER_OF_CHAIR = 'number_of_chair';
+     /**
      * @var string
      */
     private const HEADER_IMAGE = 'header_image';
@@ -44,6 +48,10 @@ final class ValueStoreSettings implements Settings
      * @var string
      */
     private const IS_EXPEDITION_SHOWN_IN_NAVIGATION = 'navigation_show_expedition';
+    /**
+     * @var string
+     */
+    private const IS_BBD_SHOWN_IN_NAVIGATION = 'navigation_show_bbd';
 
     private Valuestore $store;
 
@@ -56,6 +64,7 @@ final class ValueStoreSettings implements Settings
     {
         $allowedKeys = [
             static::NUMBER_OF_EXTERN,
+            static::NUMBER_OF_CHAIR,
             static::HEADER_IMAGE,
             static::PRIVATE_ALBUMS,
             static::IS_LOGIN_SHOWN_IN_NAVIGATION,
@@ -63,6 +72,7 @@ final class ValueStoreSettings implements Settings
             static::IS_SYMPOSIUM_SHOWN_IN_NAVIGATION,
             static::IS_PIENTER_SHOWN_IN_NAVIGATION,
             static::IS_EXPEDITION_SHOWN_IN_NAVIGATION,
+            static::IS_BBD_SHOWN_IN_NAVIGATION,
         ];
 
         foreach ($settings as $key => $value) {
@@ -77,6 +87,17 @@ final class ValueStoreSettings implements Settings
     public function contactNumberOfExtern() : string
     {
         $number = $this->store->get(self::NUMBER_OF_EXTERN);
+
+        if ( ! is_string($number)) {
+            return '';
+        }
+
+        return $number;
+    }
+
+    public function contactNumberOfChair() : string
+    {
+        $number = $this->store->get(self::NUMBER_OF_CHAIR);
 
         if ( ! is_string($number)) {
             return '';
@@ -165,11 +186,26 @@ final class ValueStoreSettings implements Settings
         return (bool) $value;
     }
 
+    public function isBBDShownInNavigation() : bool
+    {
+        $value = $this->store->get(self::IS_BBD_SHOWN_IN_NAVIGATION);
+
+        if ($value === null) {
+            return false;
+        }
+
+        return (bool) $value;
+    }
     public function getIterator() : Traversable
     {
         yield static::NUMBER_OF_EXTERN => [
             'text' => 'Telephone number of extern',
             'value' => $this->contactNumberOfExtern(),
+            'type' => 'text'
+        ];
+        yield static::NUMBER_OF_CHAIR => [
+            'text' => 'Telephone number of chair',
+            'value' => $this->contactNumberOfChair(),
             'type' => 'text'
         ];
         yield static::HEADER_IMAGE => [
@@ -205,6 +241,11 @@ final class ValueStoreSettings implements Settings
         yield static::IS_EXPEDITION_SHOWN_IN_NAVIGATION => [
             'text' => 'Add a link to expedition strategy in the navigation menu',
             'value' => $this->isExpeditionShownInNavigation(),
+            'type' => 'toggle'
+        ];
+        yield static::IS_BBD_SHOWN_IN_NAVIGATION => [
+            'text' => 'Add a link to Beta Business Days in the navigation menu',
+            'value' => $this->isBBDShownInNavigation(),
             'type' => 'toggle'
         ];
     }

--- a/tests/Features/Shared/SettingsFeature.php
+++ b/tests/Features/Shared/SettingsFeature.php
@@ -25,6 +25,7 @@ class SettingsFeature extends TestCase
 
         $this
              ->type('hoi', 'number_of_extern')
+             ->type('hoi', 'number_of_chair')
              ->type('image', 'header_image')
             ->check('private_albums')
             ->check('navigation_show_login')
@@ -32,10 +33,12 @@ class SettingsFeature extends TestCase
             ->uncheck('navigation_show_symposium')
             ->uncheck('navigation_show_pienter')
             ->uncheck('navigation_show_expedition')
+            ->uncheck('navigation_show_bbd')
             ->press('Save');
 
         $settings->updateSettings([
             "number_of_extern" => "hoi",
+            "number_of_chair" => "hoi",
             "header_image" => "image",
             "private_albums" => true,
             "navigation_show_login" => true,
@@ -43,6 +46,7 @@ class SettingsFeature extends TestCase
             "navigation_show_symposium" => false,
             "navigation_show_pienter" => false,
             "navigation_show_expedition" => false,
+            "navigation_show_bbd" => false,
         ])->shouldHaveBeenCalled();
     }
 }


### PR DESCRIPTION
I removed the phone number of the board room from the footer and the contact page. Just like the external phone number, the phone number of the chair can be entered in admin and it replaces the number on the footer and contact page. Also BBD can be set in the header.