### PR TITLE
Added master example for study and description for photos

### DIFF
--- a/resources/views/association/photos/index.blade.php
+++ b/resources/views/association/photos/index.blade.php
@@ -13,6 +13,9 @@
     <h1 class="section-header section-header--centered mb-5">
         Photos
     </h1>
+    <p>
+      Welcome to our fun, lovely and colourful pictures of our experiences in T.F.V. 'Professor Francken', with many beautiful portraits of beautiful people. If at any time you feel camera shy, just let us know at <a href="mailto: Fotociefrancken@gmail.com">Fotociefrancken@gmail.com</a> or let board know at <a href="mailto: board@professorfrancken.nl">board@professorfrancken.nl</a>, and we will make sure those photos disappear into thin air.
+  </p>
 
     <ul class="agenda-list list-unstyled photo-grid">
         @foreach ($albums as $album)

--- a/resources/views/registration/_study-details.blade.php
+++ b/resources/views/registration/_study-details.blade.php
@@ -12,7 +12,7 @@
                     <x-forms.text
                         :name='"study_name[{$number}]"'
                         label="Study"
-                        placeholder="Bsc Applied Physics"
+                        placeholder="Bsc or Msc Applied Physics"
                         required
                     />
                 </div>


### PR DESCRIPTION
In the signup up form, people fill in their study and it only gives an example as bsc Applied Physics. It now shows Bsc or Msc Applied Phyics.

Furthermore, on the photo page, there is now a small introduction from the fotocie.