### PR TITLE
Remove latest news

### DIFF
--- a/config/francken/navigation.php
+++ b/config/francken/navigation.php
@@ -20,7 +20,7 @@ return [
             'url' => '/association',
             'title' => 'Association',
             'subItems' => [
-                ['url' => "/association/news", 'title' => 'News', 'description' => 'The latest news from the association', 'icon' => 'fas fa-newspaper'],
+                // ['url' => "/association/news", 'title' => 'News', 'description' => 'The latest news from the association', 'icon' => 'fas fa-newspaper'],
                 ['url' => "/association/activities", 'title' => 'Activities', 'description' => 'Upcoming career, study and social activities', 'icon' => 'fas fa-calendar-week'],
                 ['url' => "/association/history", 'title' => 'History', 'description' => 'Curious about the history of our association, read it here', 'icon' => 'far fa-clock'],
                 ['url' => "/association/honorary-members", 'title' => 'Honorary members', 'description' => 'Francken knows two honnorary members: Francken and De Hosson', 'icon' => 'fas fa-award'],

--- a/resources/views/homepage/homepage.blade.php
+++ b/resources/views/homepage/homepage.blade.php
@@ -8,7 +8,7 @@
 
     @include("homepage._about-francken")
 
-    @include("homepage._news")
+    {{-- @include("homepage._news") --}}
 
     @include("homepage._pillars")
 @endsection


### PR DESCRIPTION
Since board does not want to maintain the latest news page, it is now no longer visible on the site. Unless someone types in the url ...